### PR TITLE
CDI-33 fire PSAT for added annotated types

### DIFF
--- a/api/src/main/java/javax/enterprise/inject/spi/ProcessSyntheticAnnotatedType.java
+++ b/api/src/main/java/javax/enterprise/inject/spi/ProcessSyntheticAnnotatedType.java
@@ -1,0 +1,44 @@
+package javax.enterprise.inject.spi;
+
+/**
+ * <p>
+ * The container fires an event of this type for each Java class or interface added by
+ * {@link BeforeBeanDiscovery#addAnnotatedType(AnnotatedType)}.
+ * </p>
+ * <p>
+ * Any observer of this event is permitted to wrap and/or replace the
+ * {@link javax.enterprise.inject.spi.AnnotatedType}. The container must use the final value of this
+ * property, after all observers have been called, to discover the types and read the annotations of
+ * the program elements.
+ * </p>
+ * <p>
+ * For example, the following observer decorates the
+ * {@link javax.enterprise.inject.spi.AnnotatedType} for every class that is added by
+ * {@link BeforeBeanDiscovery#addAnnotatedType(AnnotatedType)}.
+ * </p>
+ * 
+ * <pre>
+ * public &lt;T&gt; void decorateAnnotatedType(@Observes ProcessSyntheticAnnotatedType&lt;T&gt; pat) {
+ *    pat.setAnnotatedType(decorate(pat.getAnnotatedType()));
+ * }
+ * </pre>
+ * <p>
+ * If any observer method of a {@code ProcessSyntheticAnnotatedType} event throws an exception, the
+ * exception is treated as a definition error by the container.
+ * </p>
+ * 
+ * @author David Allen
+ * @author Pete Muir
+ * @see AnnotatedType
+ * @see ProcessAnnotatedType
+ * @param <X> The class being annotated
+ */
+interface ProcessSyntheticAnnotatedType<X> extends ProcessAnnotatedType<X> {
+   /**
+    * Get the extension instance which added the {@link AnnotatedType} for which this event is being
+    * fired.
+    * 
+    * @return the extension instance
+    */
+   public Extension getSource();
+}

--- a/spec/en/modules/spi.xml
+++ b/spec/en/modules/spi.xml
@@ -1214,16 +1214,25 @@ public BeanAttributes<?> createBeanAttributes(AnnotatedMember<?> member);]]></pr
       <title><literal>ProcessAnnotatedType</literal> event</title>
       
       <para>The container must fire an event for each Java class or interface it discovers
-      in a bean archive, before it reads the declared annotations.</para>
+      in a bean archive, and for annotated type added by 
+      <literal>BeforeBeanDiscovery.addAnnotatedType()</literal>, before it reads the 
+      declared annotations.</para>
       
       <para>The event object must be of type 
       <literal>javax.enterprise.inject.spi.ProcessAnnotatedType&lt;X&gt;</literal>, 
-      where <literal>X</literal> is the class.</para>
+      where <literal>X</literal> is the class, for classes and interfaces discovered 
+      in a bean archive, or of type 
+      <literal>javax.enterprise.inject.spi.ProcessSyntheticAnnotatedType&lt;X&gt;</literal>
+      for classes and interfaces added by <literal>BeforeBeanDiscovery.addAnnotatedType()</literal>.</para>
       
       <programlisting><![CDATA[public interface ProcessAnnotatedType<X> {
     public AnnotatedType<X> getAnnotatedType();
     public void setAnnotatedType(AnnotatedType<X> type);
     public void veto();
+}]]></programlisting>
+
+      <programlisting><![CDATA[interface ProcessSyntheticAnnotatedType<X> extends ProcessAnnotatedType<X> {
+    public Extension getSource();
 }]]></programlisting>
 
     <itemizedlist>
@@ -1236,6 +1245,10 @@ public BeanAttributes<?> createBeanAttributes(AnnotatedMember<?> member);]]></pr
     </listitem>
     <listitem>      
       <para><literal>veto()</literal> forces the container to ignore the type.</para>
+    </listitem>
+    <listitem>      
+      <para><literal>getSource()</literal> returns the <literal>Extension</literal> instance
+      that added the annotated type.</para>
     </listitem>
     </itemizedlist>
     


### PR DESCRIPTION
- Add an event type ProcessSyntheticAnnotatedType
  that is fired for every java class or interface 
  added by BeforeBeanDiscovery.addAnnotatedType
