### PR TITLE
CDI-14: Provide more convenient access for programmatic access

### DIFF
--- a/api/src/main/java/javax/enterprise/inject/spi/CDI.java
+++ b/api/src/main/java/javax/enterprise/inject/spi/CDI.java
@@ -1,0 +1,108 @@
+package javax.enterprise.inject.spi;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.enterprise.inject.Instance;
+
+/**
+ * Provides access to the current container.
+ * 
+ * @author Pete Muir
+ * 
+ */
+public abstract class CDI<T> implements Instance<T> {
+
+   protected static final Set<CDIProvider> providers = new HashSet<CDIProvider>();
+
+   /**
+    * <p>
+    * Get the CDI instance that provides access to the current container.
+    * </p>
+    * 
+    * <p>
+    * If there are no providers available, an {@link IllegalStateException} is thrown, otherwise the
+    * first provider which can access the container is used.
+    * </p>
+    * 
+    * @throws IllegalStateException if no CDI provider is available
+    * 
+    */
+   public static <T> CDI<T> current() {
+      CDI<T> cdi = null;
+
+      if (providers.size() == 0) {
+         findAllProviders();
+      }
+      for (CDIProvider provider : providers) {
+         cdi = provider.getCDI();
+         if (cdi != null)
+            break;
+      }
+      if (cdi == null) {
+         throw new IllegalStateException("Unable to access CDI");
+      }
+      return cdi;
+   }
+
+   // Helper methods
+
+   private static void findAllProviders() {
+      try {
+         ClassLoader loader = Thread.currentThread().getContextClassLoader();
+         Enumeration<URL> resources = loader.getResources("META-INF/services/" + CDIProvider.class.getName());
+         Set<String> names = new HashSet<String>();
+         while (resources.hasMoreElements()) {
+            URL url = resources.nextElement();
+            InputStream is = url.openStream();
+            try {
+               names.addAll(providerNamesFromReader(new BufferedReader(new InputStreamReader(is))));
+            } finally {
+               is.close();
+            }
+         }
+         for (String s : names) {
+            Class<CDIProvider> providerClass = (Class<CDIProvider>) loader.loadClass(s);
+            providers.add(providerClass.newInstance());
+         }
+      } catch (IOException e) {
+         throw new IllegalStateException(e);
+      } catch (InstantiationException e) {
+         throw new IllegalStateException(e);
+      } catch (IllegalAccessException e) {
+         throw new IllegalStateException(e);
+      } catch (ClassNotFoundException e) {
+         throw new IllegalStateException(e);
+      }
+   }
+
+   private static final Pattern nonCommentPattern = Pattern.compile("^([^#]+)");
+
+   private static Set<String> providerNamesFromReader(BufferedReader reader) throws IOException {
+      Set<String> names = new HashSet<String>();
+      String line;
+      while ((line = reader.readLine()) != null) {
+         line = line.trim();
+         Matcher m = nonCommentPattern.matcher(line);
+         if (m.find()) {
+            names.add(m.group().trim());
+         }
+      }
+      return names;
+   }
+
+   /**
+    * Get the CDI BeanManager for the current context
+    * 
+    * @return
+    */
+   public abstract BeanManager getBeanManager();
+}

--- a/api/src/main/java/javax/enterprise/inject/spi/CDIProvider.java
+++ b/api/src/main/java/javax/enterprise/inject/spi/CDIProvider.java
@@ -1,0 +1,18 @@
+package javax.enterprise.inject.spi;
+
+
+/**
+ * Interface implemented by a CDI provider to provide access to the current container
+ * 
+ * @author Pete Muir
+ */
+public interface CDIProvider {
+
+   /**
+    * Provides access to the current container
+    * 
+    * @return the CDI instance for the current container
+    */
+   public <T> CDI<T> getCDI();
+
+}

--- a/spec/en/modules/spi.xml
+++ b/spec/en/modules/spi.xml
@@ -321,8 +321,7 @@
   <section id="beanmanager">
     <title>The <literal>BeanManager</literal> object</title>
     
-    <para>Portable extensions sometimes interact directly with the container via 
-    programmatic API call. The interface <literal>javax.enterprise.inject.spi.BeanManager</literal> 
+    <para>The interface <literal>javax.enterprise.inject.spi.BeanManager</literal> 
     provides operations for obtaining contextual references for beans, along with many 
     other operations of use to portable extensions.</para>
     
@@ -334,14 +333,41 @@
     
     <programlisting>@Inject BeanManager manager;</programlisting>
     
-    <para>Java EE components may obtain an instance of <literal>BeanManager</literal> 
-    from JNDI by looking up the name <literal>java:comp/BeanManager</literal>.</para>
-    
-    <para>Web components may obtain an instance of <literal>BeanManager</literal> 
-    by calling <literal>ServletContext.getAttribute("javax.enterprise.inject.spi.BeanManager")</literal>.</para>
-    
     <para>Any operation of <literal>BeanManager</literal> may be called at any time
     during the execution of the application.</para>
+    
+    <section id="provider">
+      <title>Obtaining a reference to the CDI container</title>
+    
+      <para>Portable extensions sometimes interact directly with the container via 
+      programmatic API call. The abstract <literal>javax.enterprise.inject.spi.CDI</literal>
+      provides access to the <literal>BeanManager</literal> as well providing lookup of
+      bean instances.</para> 
+      
+      <programlisting>public abstract class CDI<T> implements Instance<T> {
+   public static <T> CDI<T> current() { ... }
+   public abstract BeanManager getBeanManager();
+}</programlisting>
+      
+      <para>A portable extension may obtain a reference to the current container by 
+      calling <literal>CDI.current()</literal>.</para>
+      
+      <para> When <literal>CDI.current()</literal> is called, the first 
+      <literal>javax.enterprise.inject.spi.CDIProvider</literal> is loaded, and the 
+      <literal>CDIProvider.getCDI()</literal> method called. If no providers are
+      available an IllegalStateException is thrown.</para>
+      
+      <programlisting><![CDATA[public interface CDIProvider {
+   public <T> CDI<T> getCDI();
+}]]></programlisting>
+      
+      <para>Java EE components may obtain an instance of <literal>BeanManager</literal> 
+      from JNDI by looking up the name <literal>java:comp/BeanManager</literal>.</para>
+    
+      <para>Web components may obtain an instance of <literal>BeanManager</literal> 
+      by calling <literal>ServletContext.getAttribute("javax.enterprise.inject.spi.BeanManager")</literal>.</para>
+  
+  </section>
     
     <section>
       <title>Obtaining a contextual reference for a bean</title>


### PR DESCRIPTION
- Add a CDI class which allows programmatic lookup
  of the BeanManager and implements Instance
- Add a CDI provider which is used by implementors
  to provide the CDI object
