### PR TITLE
CDI-234 equality of qualifiers/interceptor bindings

### DIFF
--- a/api/src/main/java/javax/enterprise/util/Unordered.java
+++ b/api/src/main/java/javax/enterprise/util/Unordered.java
@@ -1,0 +1,52 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package javax.enterprise.util;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * <p>
+ * Indicates that the order of an array-valued member of a qualifier or interceptor 
+ * binding should be ignored when performing resolution. 
+ * </p>
+ * 
+ * <pre>
+ * &#064;Qualifier
+ * &#064;Retention(RUNTIME)
+ * &#064;Target({ METHOD, FIELD, PARAMETER, TYPE })
+ * public @interface PayBy {
+ *     
+ *     &#64;Unordered
+ *     PaymentMethod[] value();
+ * }
+ * </pre>
+ * 
+ * @author Pete Muir
+ * 
+ * @see javax.inject.Qualifier &#064;Qualifier
+ * @see javax.interceptor.InterceptorBinding &#064;InterceptorBinding
+ * 
+ */
+@Retention(RUNTIME)
+@Target(METHOD)
+public @interface Unordered {
+}

--- a/spec/en/modules/injectionelresolution.xml
+++ b/spec/en/modules/injectionelresolution.xml
@@ -522,11 +522,26 @@
 
       <programlisting>@Inject @PayBy(CREDIT_CARD) PaymentProcessor paymentProcessor;</programlisting>
 
-      <para>The container calls the <literal>equals()</literal> method of the
-      annotation member value to compare values.</para>
+      <para>Annotation member values are compared using the rules defined by 
+      <literal>Annotation.equals()</literal>.</para>
 
-      <para>An annotation member may be excluded from consideration using the
-      <literal>@Nonbinding</literal> annotation.</para>
+      <para>When comparing array-valued members the order of the array matters. The
+      order of the array may be ignored by annotating the array-valued member with
+      <literal>@Unordered</literal>.</para>
+
+      <programlisting> @Qualifier
+@Retention(RUNTIME)
+@Target({ METHOD, FIELD, PARAMETER, TYPE })
+public @interface PayBy {
+     
+    @Unordered
+    PaymentMethod[] value();
+}</programlisting>
+
+      <para>Any annotation member, defined on the annotation, or transitivly on an 
+      annotation-valued member, or on an annotation contained in an array-valued 
+      member may be excluded from consideration using the <literal>@Nonbinding</literal>
+      annotation.</para>
       
       <programlisting>@Qualifier
 @Retention(RUNTIME)
@@ -536,11 +551,6 @@ public @interface PayBy {
     @Nonbinding String comment() default "";
 }</programlisting>
 
-      <para>Array-valued or annotation-valued members of a qualifier type should be 
-      annotated <literal>@Nonbinding</literal> in a portable application. If an
-      array-valued or annotation-valued member of a qualifier type is not annotated 
-      <literal>@Nonbinding</literal>, non-portable behavior results.</para>
-      
     </section>
 
     <section>

--- a/spec/en/modules/interceptors.xml
+++ b/spec/en/modules/interceptors.xml
@@ -405,8 +405,9 @@ public class ShoppingCart { ... }</programlisting>
         <programlisting>@Transactional
 public class ShoppingCart { ... }</programlisting>
 
-        <para>Annotation member values are compared using <literal>equals()</literal>.</para>
-      
+        <para>Annotation member values are compared using the rules defined by 
+        <literal>Annotation.equals()</literal>.</para>
+
         <para>An annotation member may be excluded from consideration using the
         <literal>@Nonbinding</literal> annotation.</para>
       
@@ -418,11 +419,6 @@ public @interface Transactional {
    @Nonbinding boolean requiresNew() default false;
 }</programlisting>
 
-        <para>Array-valued or annotation-valued members of an interceptor binding 
-        type should be annotated <literal>@Nonbinding</literal> in a portable 
-        application. If an array-valued or annotation-valued member of an interceptor 
-        binding type is not annotated <literal>@Nonbinding</literal>, non-portable 
-        behavior results.</para>
 
         <para>If the set of interceptor bindings of a bean class or interceptor, including
         bindings inherited from stereotypes and other interceptor bindings, has two


### PR DESCRIPTION
- Allow array members to not be @NonBinding
- Specify that the rules from Annotation.equals should be followed when comparing qualifier equality.
