### PR TITLE
CDI180, clarify that remote ejb invocation only destroys the request context if it also created it

### DIFF
--- a/spec/en/modules/scopescontexts.xml
+++ b/spec/en/modules/scopescontexts.xml
@@ -899,7 +899,8 @@
         </listitem>
         <listitem>
           <para>after the EJB remote method invocation, asynchronous method invocation, 
-          timeout or message delivery completes, or</para>
+          timeout or message delivery completes if it did not already exist when the invocation 
+          occurred, or</para>
         </listitem>
         <listitem>
           <para>after the <literal>@PostConstruct</literal> callback completes, if it did not already exist


### PR DESCRIPTION
See how this looks, but there are alternatives.  For example, we could instead add a general note that states the context doesn't end unless it was also created for that instance so we don't have to write this per line it applies to.
