### PR TITLE
CDI-124 Clarify usage of ObserverMethod

### DIFF
--- a/api/src/main/java/javax/enterprise/inject/spi/ObserverMethod.java
+++ b/api/src/main/java/javax/enterprise/inject/spi/ObserverMethod.java
@@ -35,7 +35,9 @@ import javax.enterprise.event.TransactionPhase;
  */
 public interface ObserverMethod<T> {
     /**
-     * Obtains the bean {@linkplain Class class} of the bean that declares the observer method.
+     * <p>
+     * Obtains the {@linkplain Class class} of the type that declares the observer method.
+     * </p>
      * 
      * @return the defining {@linkplain Class class}
      */
@@ -70,14 +72,28 @@ public interface ObserverMethod<T> {
     public TransactionPhase getTransactionPhase();
 
     /**
+     * <p>
      * Calls the observer method, passing the given event object.
+     * </p>
+     * 
+     * <p>
+     * The implementation of {@link #notify(Object)} for a custom observer method is responsible for
+     * deciding whether to call the method if the {@link #getReception()} returns {@link Reception#IF_EXISTS}. 
+     * </p>
      * 
      * @param event the event object
      */
     public void notify(T event);
     
     /**
+     * <p>
      * Calls the observer method, passing the given event object.
+     * </p>
+     * 
+     * <p>
+     * The implementation of {@link #notify(Object, Set)} for a custom observer method is responsible for
+     * deciding whether to call the method if the {@link #getReception()} returns {@link Reception#IF_EXISTS}. 
+     * </p>
      * 
      * @param event the event object
      * @param qualifiers the qualifiers with which the event was called

--- a/spec/en/modules/events.xml
+++ b/spec/en/modules/events.xml
@@ -536,9 +536,9 @@ else {
     
       <para>For a custom implementation of the <literal>ObserverMethod</literal>
       interface defined in <xref linkend="observermethod"/>, the container must
-      call <literal>getReception()</literal> and <literal>getTransactionPhase()</literal>
-      to determine if the observer method is a conditional or transactional observer
-      method, and <literal>notify()</literal> to invoke the method.</para>
+      call <literal>getTransactionPhase()</literal> to determine if the observer
+      method is transactional observer method, and <literal>notify()</literal> 
+      to invoke the method.</para>
       
       <note>
          <para>CDI 1.1 implementations should call the <code>notify</code> method

--- a/spec/en/modules/spi.xml
+++ b/spec/en/modules/spi.xml
@@ -178,8 +178,8 @@
 
       <itemizedlist>
         <listitem>
-          <para><literal>getBeanClass()</literal> returns the bean class of the bean 
-          that declares the observer method.</para>
+          <para><literal>getBeanClass()</literal> returns the class of the type that declares the
+          observer method.</para>
         </listitem>
         <listitem>
           <para><literal>getObservedType()</literal> and <literal>getObservedQualifiers()</literal>
@@ -195,7 +195,7 @@
         </listitem>
         <listitem>
           <para><literal>notify()</literal> calls the observer method, as defined in
-          <xref linkend="observers"/>.</para>
+          <xref linkend="observernotification"/>.</para>
         </listitem>
       </itemizedlist>
       


### PR DESCRIPTION
- deprecate getBeanClass()
- notify() is responsible for implementing conditional observers
