### PR TITLE
CDI-6, CDI-74, CDI-44

### DIFF
--- a/api/src/main/java/javax/enterprise/inject/spi/Producer.java
+++ b/api/src/main/java/javax/enterprise/inject/spi/Producer.java
@@ -36,12 +36,16 @@ public interface Producer<T> {
      * </p>
      * <p>
      * If the {@code Producer} represents a class, this will invoke the constructor annotated {@link javax.inject.Inject} if it
-     * exists, or the constructor with no parameters otherwise. If the class has interceptors, <tt>produce()</tt> is responsible
+     * exists, or the constructor with no parameters otherwise. If the class has interceptors or decorators, <tt>produce()</tt> is responsible
      * for building the interceptors and decorators of the instance.
      * </p>
      * <p>
      * If the {@code Producer} represents a producer field or method, this will invoke the producer method on, or access the
      * producer field of, a contextual instance of the bean that declares the producer.
+     * </p>
+     * <p>
+     * The produced instance can be reflectively operated on using the Java Reflection API, allowing access and operate on the 
+     * fields, methods and constructors of the produced instance.
      * </p>
      * 
      * @param ctx The {@link javax.enterprise.context.spi.CreationalContext} to use for the produced object

--- a/spec/en/modules/implementation.xml
+++ b/spec/en/modules/implementation.xml
@@ -929,6 +929,10 @@ PaymentService paymentService;</programlisting>
       constructor by the container; the returned object is not bound to any context; 
       no dependencies are injected by the container; and the lifecycle of the new 
       instance is not managed by the container.</para>
+
+      <para>There is no requirement for a bean class to declare a constructor
+      that accepts no parameters, except as defined in <xref linkend="unproxyable" />.
+      </para>
       
       <section>
         <title>Declaring a bean constructor</title>

--- a/spec/en/modules/spi.xml
+++ b/spec/en/modules/spi.xml
@@ -226,9 +226,12 @@
           <para><literal>produce()</literal> calls the constructor annotated 
           <literal>@Inject</literal> if it exists, or the constructor with no 
           parameters otherwise, as defined in <xref linkend="instantiation"/>,
-          and returns the resulting instance. If the class has interceptors, 
-          <literal>produce()</literal> is responsible for building the 
-          interceptors and decorators of the instance.</para>
+          and returns the resulting instance. If the class has interceptors or
+          decorators, <literal>produce()</literal> is responsible for building
+          the interceptors and decorators of the resulting instance. The 
+          container must support using the Java Reflection API to perform 
+          reflective operations on the fields, methods and constructors of 
+          the resulting instance.</para>
         </listitem>
        <listitem>
           <para><literal>dispose()</literal> does nothing.</para>


### PR DESCRIPTION
- emphasise there is no limitation on bean constructors, except for client proxies
- require that instance from produce() can be reflected on
