### PR TITLE
CDI-132 Clarify that all methods and fields on the type hierarchy must b...

### DIFF
--- a/api/src/main/java/javax/enterprise/inject/spi/AnnotatedMember.java
+++ b/api/src/main/java/javax/enterprise/inject/spi/AnnotatedMember.java
@@ -51,10 +51,10 @@ public interface AnnotatedMember<X> extends Annotated {
 
     /**
      * <p>
-     * Get the {@linkplain AnnotatedType type} which declares this member.
+     * Get the {@linkplain AnnotatedType type} which defines this member.
      * </p>
      * 
-     * @return the type which declares this member
+     * @return the type which defines this member
      */
     public AnnotatedType<X> getDeclaringType();
 }

--- a/spec/en/modules/spi.xml
+++ b/spec/en/modules/spi.xml
@@ -838,16 +838,22 @@ public BeanAttributes<?> createBeanAttributes(AnnotatedMember<?> member);]]></pr
 
     <itemizedlist>
       <listitem>
-        <para><literal>getConstructors()</literal> returns all the constructors
-        declared for the type.</para>
+        <para><literal>getConstructors()</literal> returns all default-access, public, 
+        protected or private constructors declared for the type.</para>
       </listitem>
       <listitem>
-        <para><literal>getMethods()</literal> returns all the methods declared
-        on the type and those declared on any supertypes.</para>
+        <para><literal>getMethods()</literal> returns all default-access, public, 
+        protected or private methods declared on the type and those declared on 
+        any supertypes. The container should call 
+        <literal>AnnotatedMethod.getJavaMember().getDeclaringClass()</literal> to 
+        determine the type in the type hierarchy that declared the method.</para>
       </listitem>
       <listitem>
-        <para><literal>getFields()</literal> returns all the fields declared
-        on the type and those declared on any supertypes.</para>
+        <para><literal>getFields()</literal> returns all default-access, public, 
+        protected or private fields declared on the type and those declared on any
+        supertypes.  The container should call 
+        <literal>AnnotatedField.getJavaMember().getDeclaringClass()</literal> to 
+        determine the type in the type hierarchy that declared the field.</para>
       </listitem>
     </itemizedlist>
     
@@ -886,7 +892,8 @@ public BeanAttributes<?> createBeanAttributes(AnnotatedMember<?> member);]]></pr
 }]]></programlisting>
 
     <para>The interface <literal>javax.enterprise.inject.spi.AnnotatedMemember</literal> 
-    exposes the <literal>Member</literal> object and the declaring type of the member.</para>
+    exposes the <literal>Member</literal> object and the <literal>AnnotatedType</literal>
+    that defines the member.</para>
 
     <programlisting><![CDATA[public interface AnnotatedMember<X> 
         extends Annotated {
@@ -897,6 +904,11 @@ public BeanAttributes<?> createBeanAttributes(AnnotatedMember<?> member);]]></pr
 
     <para>The interface <literal>javax.enterprise.inject.spi.AnnotatedCallable</literal> 
     exposes the parameters of an invokable object.</para>
+
+    <para>Contexts and Dependency Injection for Java EE 1.1 deprecated the method 
+    <literal>AnnotatedMember.isStatic</literal>. The container should instead call
+    <literal>AnnotatedMember.getJavaMember().getModifiers()</literal> to determine if
+    the member is static.</para>
 
     <programlisting><![CDATA[public interface AnnotatedCallable<X> 
         extends AnnotatedMember<X> {


### PR DESCRIPTION
...e included
- Note that this covers public, protected, default-access and private
- Deprecate isStatic(), it's not useful
- Try to clear up the usage of declared, as it means something specific, which doesn't fit with AnnotatedType
- Indicate that the container must use the underlying Java Reflection API to determine type hierarchy
