### PR TITLE
Upgrade weld-parent to version 19

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -4,7 +4,7 @@
    <parent>
       <groupId>org.jboss.weld</groupId>
       <artifactId>weld-parent</artifactId>
-      <version>17</version>
+      <version>19</version>
       <relativePath />
    </parent>
 


### PR DESCRIPTION
Makes CDI API releases less painful
