### PR TITLE
CDI-282, CDI-269, CDI-138

### DIFF
--- a/api/src/main/java/javax/enterprise/inject/spi/BeforeBeanDiscovery.java
+++ b/api/src/main/java/javax/enterprise/inject/spi/BeforeBeanDiscovery.java
@@ -46,6 +46,19 @@ public interface BeforeBeanDiscovery {
      * @param qualifier The annotation to treat as a qualifier
      */
     public void addQualifier(Class<? extends Annotation> qualifier);
+    
+    /**
+     * <p>
+     * Declares an annotation type as a {@linkplain javax.inject.Qualifier} qualifier type.
+     * </p>
+     * 
+     * <p>
+     * This is only required if you wish to make an annotation a qualifier without adding {@link Qualifier} to it.
+     * </p>
+     * 
+     * @param qualifier The annotation to treat as a qualifier
+     */
+    public void addQualifier(AnnotatedType<? extends Annotation> qualifier);
 
     /**
      * <p>
@@ -83,6 +96,19 @@ public interface BeforeBeanDiscovery {
      */
     public void addStereotype(Class<? extends Annotation> stereotype, Annotation... stereotypeDef);
 
+    /**
+     * <p>
+     * Declares an annotation type as an {@linkplain Interceptor interceptor} binding type.
+     * </p>
+     * 
+     * <p>
+     * This is only required if you wish to make an annotation an interceptor binding type without adding {@link InterceptorBinding} to it.
+     * </p>
+     * 
+     * @param bindingType The annotation type to treat as an interceptor binding type
+     */
+    public void addInterceptorBinding(AnnotatedType<? extends Annotation> bindingType);
+    
     /**
      * <p>
      * Declares an annotation type as an {@linkplain Interceptor interceptor} binding type, and specifies its meta-annotations.

--- a/spec/spi.asciidoc
+++ b/spec/spi.asciidoc
@@ -729,9 +729,11 @@ The container must fire an event before it begins the bean discovery process. Th
 ----
 public interface BeforeBeanDiscovery {
     public void addQualifier(Class<? extends Annotation> qualifier);
+    public void addQualifier(AnnotatedType<? extends Annotation> qualifier);
     public void addScope(Class<? extends Annotation> scopeType, boolean normal, boolean passivating);
     public void addStereotype(Class<? extends Annotation> stereotype, Annotation... stereotypeDef);
     public void addInterceptorBinding(Class<? extends Annotation> bindingType, Annotation... bindingTypeDef);
+    public void addInterceptorBinding(AnnotatedType<? extends Annotation> bindingType);
     public void addAnnotatedType(AnnotatedType<?> type);
 }
 ----
@@ -867,14 +869,12 @@ If any observer method of a +ProcessModule+ event throws an exception, the excep
 
 The container must fire an event, before it processes a type, for each:
 
-* Java class, interface, enum or annotation discovered in a bean archive,
+* Java class, interface or enum in a bean archive,
 * Annotated type added by +BeforeBeanDiscovery.addAnnotatedType()+,
-* Annotation added by +BeforeBeanDiscovery.addInterceptorBinding()+, +BeforeBeanDiscovery.addQualifier()+, +BeforeBeanDiscovery.addScope()+ or +BeforeBeanDiscovery.addStereotype()+.
-
 
 An event is not fired for any type annotated with +@Vetoed+, or in a package annotated with +@Vetoed+.
 
-The event object must be of type +javax.enterprise.inject.spi.ProcessAnnotatedType<X>+, where +X+ is the class, for types discovered in a bean archive, or of type +javax.enterprise.inject.spi.ProcessSyntheticAnnotatedType<X>+ for types added by +BeforeBeanDiscovery.addAnnotatedType()+, +BeforeBeanDiscovery.addInterceptorBinding()+, +BeforeBeanDiscovery.addQualifier()+, +BeforeBeanDiscovery.addScope()+ or +BeforeBeanDiscovery.addStereotype()+.
+The event object must be of type +javax.enterprise.inject.spi.ProcessAnnotatedType<X>+, where +X+ is the class, for types discovered in a bean archive, or of type +javax.enterprise.inject.spi.ProcessSyntheticAnnotatedType<X>+ for types added by +BeforeBeanDiscovery.addAnnotatedType()+.
 
 The annotation +@WithAnnotations+ may be applied to the event parameter. If the annotation is applied, the container must only deliver +ProcessAnnotatedType+ events for types which contain at least one of the annotations specified. The annotation can appear on the type, on any field, method or constructor declared by the type, or on any parameter of any method or constructor declared by the type. The annotation may be applied as a meta-annotation on any annotation considered.
 


### PR DESCRIPTION
- remove fire PAT for annotations
- add methods to add qualifier and interceptor bindings with an AnnotatedType
