### PR TITLE
CDI-36: Restoring functionality reverted by CDI-271: Qualifiers of fired events should be obtainable in @Observes methods.

### DIFF
--- a/api/src/main/java/javax/enterprise/inject/spi/EventMetadata.java
+++ b/api/src/main/java/javax/enterprise/inject/spi/EventMetadata.java
@@ -1,0 +1,50 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package javax.enterprise.inject.spi;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.Set;
+
+/**
+ * Provides meta-information about an observed event payload, and may represent metadata for events fired with either of
+ * {@link javax.enterprise.event.Event} or {@link BeanManager#fireEvent(Object, Annotation...)}.
+ * <p>
+ * Instances of this class can be retrieved as a parameter of an {@literal @}{@link javax.enterprise.event.Observes}
+ * method.
+ * 
+ * @author Lincoln Baxter, III
+ */
+public interface EventMetadata
+{
+   /**
+    * Returns the {@link Set} of qualifiers with which the corresponding event payload was fired.
+    */
+   public Set<Annotation> getQualifiers();
+
+   /**
+    * Returns the {@link InjectionPoint} from which the event payload was fired, or <code>null</code> if it was fired
+    * from {@link BeanManager#fireEvent(Object, Annotation...)};
+    */
+   public InjectionPoint getInjectionPoint();
+
+   /**
+    * Returns the resolved event {@link Type}.
+    */
+   public Type getType();
+}

--- a/spec/events.asciidoc
+++ b/spec/events.asciidoc
@@ -316,6 +316,41 @@ In addition to the event parameter, observer methods may declare additional para
 public void afterLogin(@Observes LoggedInEvent event, @Manager User user, Logger log) { ... }
 ----
 
+[[event_metadata]]
+
+==== The +EventMetadata+ interface
+
+The interface +javax.enterprise.inject.spi.EventMetadata+ contains everything the container knows an observed event. 
+
+[source, java]
+----
+public interface EventMetadata
+{
+   public Set<Annotation> getQualifiers();
+   public InjectionPoint getInjectionPoint();
+   public Type getResolvedType();
+}
+----
+
+* +getQualifiers()+ returns the set of qualifiers that was fired with the corresponding event.
+* +getInjectionPoint()+ returns the +InjectionPoint+ from which this event payload was fired, or +null+ if it was fired from +BeanManager.fireEvent(...)+.
+* +getResolvedType()+ Returns the resolved event +Type+.
+
+An instance of +EventMetadata+ must exist for every observed event payload, and the observer method that observes said payload, but only if the observer method specifies +EventMetadata+ be injected as a method parameter.
+
+[[obtaining_event_metadata]]
+
+==== Obtaining +EventMetadata+ in an observer method
+
+In addition to the observed event payload and additional injected parameters, observer methods may declare a parameter of the type +EventMetadata+. This additional parameter will be supplied by the container, and can be used to obtain additional information about the observed event payload such as the qualifiers it was fired with, the +InjectionPoint+ from which it was fired (if any), and the resolved event +Type+.
+
+[source, java]
+----
+public void afterLogin(@Observes LoggedInEvent event, EventMetadata metadata) { ... }
+----
+
+If a method has more than one un-qualified parameter of type +EventMetadata+, the container automatically detects the problem and treats it as a definition error.
+
 [[conditional_observer_methods]]
 
 ==== Conditional observer methods


### PR DESCRIPTION
As discussed on the mailing list, added spec language for:

```
/**
 * Provides meta-information about an observed event payload. Can be retrieved as a parameter of an @Observes method.
 */
public interface EventMetadata
{
   /**
    * Returns the set of qualifiers with which the corresponding event payload was fired.
    */
   public Set<Annotation> getQualifiers();

   /**
    * Returns the Event<?> InjectionPoint from which this payload was fired, or null if it was fired from BeanManager.fireEvent(...);
    */
   public InjectionPoint getInjectionPoint();

   /**
    * Returns the resolved event Type.
    */
   public Type getType();
}
```
