### PR TITLE
CDI-376 BeanManager#getProducerFactory return type differs between API and spec

### DIFF
--- a/spec/src/main/doc/spi.asciidoc
+++ b/spec/src/main/doc/spi.asciidoc
@@ -556,8 +556,8 @@ The method +BeanManager.getProducerFactory()+ returns a factory capable of creat
 
 [source, java]
 ----
-public <X> ProducerFactory<? super X> getProducerFactory(AnnotatedField<? super X> field, Bean<X> declaringBean);
-public <X> ProducerFactory<? super X> getProducerFactory(AnnotatedMethod<? super X> method, Bean<X> declaringBean);
+public <X> ProducerFactory<X> getProducerFactory(AnnotatedField<? super X> field, Bean<X> declaringBean);
+public <X> ProducerFactory<X> getProducerFactory(AnnotatedMethod<? super X> method, Bean<X> declaringBean);
 ----
 
 [source, java]


### PR DESCRIPTION
CDI-376 BeanManager#getProducerFactory return type differs between API and spec
