### PR TITLE
CDI-388 Session bean specialization example is not valid

### DIFF
--- a/spec/src/main/doc/implementation.asciidoc
+++ b/spec/src/main/doc/implementation.asciidoc
@@ -226,7 +226,7 @@ public class LoginActionBean implements LoginAction { ... }
 [source, java]
 ----
 @Stateless @Mock @Specializes
-public class MockLoginActionBean implements LoginAction { ... }
+public class MockLoginActionBean extends LoginActionBean implements LoginAction { ... }
 ----
 
 [[session_bean_name]]


### PR DESCRIPTION
CDI-388 Session bean specialization example is not valid
The specialized bean now implements the LoginAction interface having all types defined by LoginAction session bean
