### PR TITLE
CDI-381 Additional implementations of Request Context

### DIFF
--- a/api/src/main/java/javax/enterprise/context/RequestScoped.java
+++ b/api/src/main/java/javax/enterprise/context/RequestScoped.java
@@ -30,10 +30,13 @@ import java.lang.annotation.Target;
 /**
  * <p>
  * Specifies that a bean is request scoped.
+ * <p/>
+ * While <tt>RequestScoped</tt> must be associated to the built-in request context required by the spec, third parties extensions are
+ * allowed to also bind it to their own context. Behavior described bellow is only related to the built-in Request Context.
  * </p>
  * 
  * <p>
- * The request scope is active:
+ * The request context is active:
  * </p>
  * 
  * <ul>

--- a/spec/src/main/doc/scopescontexts.asciidoc
+++ b/spec/src/main/doc/scopescontexts.asciidoc
@@ -437,7 +437,7 @@ Portable extensions are encouraged to fire an event with qualifier +@Initialized
 
 ==== Request context lifecycle
 
-The _request context_ is provided by a built-in context object for the built-in scope type +@RequestScoped+. The request scope is active:
+The _request context_ is provided by a built-in context object for the built-in scope type +@RequestScoped+. The request context is active:
 
 * during the +service()+ method of any servlet in the web application, during the +doFilter()+ method of any servlet filter and when the container calls any +ServletRequestListener+ or +AsyncListener+,
 * during any Java EE web service invocation,


### PR DESCRIPTION
Added a mention and replace "scope" by "context" since its a context that can be active or not
