### PR TITLE
CDI-320 Clarify whether ProcessAnnotatedType should be fired for annotations

### DIFF
--- a/spec/src/main/doc/packagingdeployment.asciidoc
+++ b/spec/src/main/doc/packagingdeployment.asciidoc
@@ -152,7 +152,7 @@ The first exclude filter will exclude all classes in +com.acme.rest+ package. Th
 
 First the container must discover types. The container discovers:
 
-* each Java class, interface (excluding annotation type) or enum deployed in an explicit bean archive, and
+* each Java class, interface (excluding the special kind of interface declaration _annotation type_) or enum deployed in an explicit bean archive, and
 * each Java class with a bean defining annotation in an implicit bean archive.
 * each session bean
 

--- a/spec/src/main/doc/spi.asciidoc
+++ b/spec/src/main/doc/spi.asciidoc
@@ -935,7 +935,7 @@ If any observer method of the +BeforeShutdown+ event throws an exception, the ex
 
 ==== +ProcessAnnotatedType+ event
 
-The container must fire an event, before it processes a type, for every Java class, interface (excluding annotation type) or enum discovered
+The container must fire an event, before it processes a type, for every Java class, interface (excluding the special kind of interface declaration _annotation type_) or enum discovered
 
 as defined in <<bean_discovery>>
 


### PR DESCRIPTION
CDI-320 Clarify whether ProcessAnnotatedType should be fired for annotations
Add a clraification regarding event triggered by AnnotatedType added thru SPI
