### PR TITLE
CDI-398 Clarify that an array with a variable component type or parameterized component type containing wildcards is not a valid bean type

### DIFF
--- a/spec/src/main/doc/definition.asciidoc
+++ b/spec/src/main/doc/definition.asciidoc
@@ -85,8 +85,11 @@ Almost any Java type may be a bean type of a bean:
 * A bean type may be a primitive type. Primitive types are considered to be identical to their corresponding wrapper types in +java.lang+.
 * A bean type may be a raw type.
 
+However, some Java types are not legal bean types :
 
-A type variable is not a legal bean type. A parameterized type that contains a wildcard type parameter is not a legal bean type.
+* A type variable is not a legal bean type.
+* A parameterized type that contains a wildcard type parameter is not a legal bean type.
+* An array type whose component type is not a legal bean type.
 
 Note that certain additional restrictions are specified in <<unproxyable>> for beans with a normal scope, as defined in <<normal_scope>>.
 


### PR DESCRIPTION
CDI-398 Clarify that an array with a variable component type or parameterized component type containing wildcards is not a valid bean type
Calcification for Arrays and type variable/wildcards
