### PR TITLE
CDI-398 Clarify that an array with a variable component type or parameterized component type containing wildcards is not a valid bean type

### DIFF
--- a/spec/src/main/doc/events.asciidoc
+++ b/spec/src/main/doc/events.asciidoc
@@ -286,6 +286,8 @@ If the event parameter does not explicitly declare any qualifier, the observer m
 
 The event parameter type may contain a type variable or wildcard.
 
+The event parameter may be an array type whose component type contains a type variable or a wildcard.
+
 [[observes]]
 
 ==== Declaring an observer method

--- a/spec/src/main/doc/implementation.asciidoc
+++ b/spec/src/main/doc/implementation.asciidoc
@@ -254,11 +254,11 @@ If a producer method sometimes returns a null value, then the producer method mu
 
 If the producer method return type is a parameterized type, it must specify an actual type parameter or type variable for each type parameter.
 
-If a producer method return type contains a wildcard type parameter the container automatically detects the problem and treats it as a definition error.
+If a producer method return type contains a wildcard type parameter or is an array type whose component type contains a wildcard type parameter, the container automatically detects the problem and treats it as a definition error.
 
 If the producer method return type is a parameterized type with a type variable, it must have scope +@Dependent+. If a producer method with a parameterized return type with a type variable declares any scope other than +@Dependent+, the container automatically detects the problem and treats it as a definition error.
 
-If a producer method return type is a type variable the container automatically detects the problem and treats it as a definition error.
+If a producer method return type is a type variable or an array type whose component type is a type variable the container automatically detects the problem and treats it as a definition error.
 
 The application may call producer methods directly. However, if the application calls a producer method directly, no parameters will be passed to the producer method by the container; the returned object is not bound to any context; and its lifecycle is not managed by the container.
 
@@ -386,11 +386,11 @@ If a producer field sometimes contains a null value when accessed, then the prod
 
 If the producer field type is a parameterized type, it must specify an actual type parameter or type variable for each type parameter.
 
-If a producer field type contains a wildcard type parameter the container automatically detects the problem and treats it as a definition error.
+If a producer field type contains a wildcard type parameter or is an array type whose component type contains a wildcard parameter, the container automatically detects the problem and treats it as a definition error.
 
 If the producer field type is a parameterized type with a type variable, it must have scope +@Dependent+. If a producer field with a parameterized type with a type variable declares any scope other than +@Dependent+, the container automatically detects the problem and treats it as a definition error.
 
-If a producer field type is a type variable the container automatically detects the problem and treats it as a definition error.
+If a producer field type is a type variable or is an array type whose component type is a type variable the container automatically detects the problem and treats it as a definition error.
 
 The application may access producer fields directly. However, if the application accesses a producer field directly, the returned object is not bound to any context; and its lifecycle is not managed by the container.
 

--- a/spec/src/main/doc/injectionelresolution.asciidoc
+++ b/spec/src/main/doc/injectionelresolution.asciidoc
@@ -157,7 +157,7 @@ For a custom implementation of the +Bean+ interface defined in <<bean>>, the con
 
 ==== Legal injection point types
 
-Any legal bean type, as defined in <<legal_bean_types>> may be the required type of an injection point. Furthermore, the required type of an injection point may contain a wildcard type parameter. However, a type variable is not a legal injection point type.
+Any legal bean type, as defined in <<legal_bean_types>> may be the required type of an injection point. Furthermore, the required type of an injection point may contain a wildcard type parameter or may be an array type whose component type contain a wildcard type parameter. However, a type variable or an array type whose component type is a type variable, is not a legal injection point type.
 
 If an injection point type is a type variable, the container automatically detects the problem and treats it as a definition error.
 


### PR DESCRIPTION
CDI-398 Clarify that an array with a variable component type or parameterized component type containing wildcards is not a valid bean type
added forgotten part about array and type variable or wildcards rules
