### PR TITLE
CDI-425 Invocation of any container lifecycle event method at runtime should result in exception

### DIFF
--- a/api/src/main/java/javax/enterprise/inject/spi/AfterBeanDiscovery.java
+++ b/api/src/main/java/javax/enterprise/inject/spi/AfterBeanDiscovery.java
@@ -48,6 +48,7 @@ public interface AfterBeanDiscovery {
      * notified.
      * 
      * @param t The definition error as a {@link java.lang.Throwable}
+     * @throws IllegalStateException if called outside of the observer method invocation
      */
     public void addDefinitionError(Throwable t);
 
@@ -58,6 +59,7 @@ public interface AfterBeanDiscovery {
      * may implement {@link javax.enterprise.inject.spi.Interceptor} or {@link javax.decorator.Decorator}.
      * 
      * @param bean The bean to add to the deployment
+     * @throws IllegalStateException if called outside of the observer method invocation
      */
     public void addBean(Bean<?> bean);
 
@@ -68,6 +70,7 @@ public interface AfterBeanDiscovery {
      * notifications.
      * 
      * @param observerMethod The custom observer method to add to the deployment
+     * @throws IllegalStateException if called outside of the observer method invocation
      */
     public void addObserverMethod(ObserverMethod<?> observerMethod);
 
@@ -75,6 +78,7 @@ public interface AfterBeanDiscovery {
      * Registers a custom {@link javax.enterprise.context.spi.Context} object with the container.
      * 
      * @param context The custom context to add to the deployment
+     * @throws IllegalStateException if called outside of the observer method invocation                
      */
     public void addContext(Context context);
 
@@ -86,6 +90,7 @@ public interface AfterBeanDiscovery {
      * @param type the {@link java.lang.Class} object
      * @param id the type identifier. If null, the fully qualifier class name of type is used
      * @return the {@link AnnotatedType}
+     * @throws IllegalStateException if called outside of the observer method invocation
      * @since 1.1
      */
     public <T> AnnotatedType<T> getAnnotatedType(Class<T> type, String id);
@@ -97,6 +102,7 @@ public interface AfterBeanDiscovery {
      * @param <T> the class or interface
      * @param type the {@link java.lang.Class} object
      * @return the {@link AnnotatedType}s
+     * @throws IllegalStateException if called outside of the observer method invocation
      * @since 1.1
      */
     public <T> Iterable<AnnotatedType<T>> getAnnotatedTypes(Class<T> type);

--- a/api/src/main/java/javax/enterprise/inject/spi/AfterDeploymentValidation.java
+++ b/api/src/main/java/javax/enterprise/inject/spi/AfterDeploymentValidation.java
@@ -35,6 +35,7 @@ public interface AfterDeploymentValidation {
      * been notified.
      * 
      * @param t The deployment problem as a {@link java.lang.Throwable}
+     * @throws IllegalStateException if called outside of the observer method invocation
      */
     public void addDeploymentProblem(Throwable t);
 

--- a/api/src/main/java/javax/enterprise/inject/spi/AfterTypeDiscovery.java
+++ b/api/src/main/java/javax/enterprise/inject/spi/AfterTypeDiscovery.java
@@ -11,6 +11,7 @@ import java.util.List;
  * Any observer of this event is permitted to add classes to, or remove classes from, the list of alternatives, list of
  * interceptors or list of decorators. The container will use the final values of these lists, after all observers have been
  * called, to determine the enabled alternatives, interceptors, and decorators for application.
+ * Changes made to these lists after the invocation of the last observer method of the {@code AfterTypeDiscovery} are ignored. 
  * </p>
  * 
  * @author Pete Muir
@@ -20,16 +21,19 @@ public interface AfterTypeDiscovery {
 
     /**
      * @return the ordered list of enabled alternatives of the bean deployment archive
+     * @throws IllegalStateException if called outside of the observer method invocation
      */
     public List<Class<?>> getAlternatives();
 
     /**
      * @return the ordered list of enabled interceptors of the bean deployment archive.
+     * @throws IllegalStateException if called outside of the observer method invocation
      */
     public List<Class<?>> getInterceptors();
 
     /**
      * @return the ordered list of enabled decorators of the bean deployment archive
+     * @throws IllegalStateException if called outside of the observer method invocation
      */
     public List<Class<?>> getDecorators();
 
@@ -51,6 +55,7 @@ public interface AfterTypeDiscovery {
      * </p>
      * 
      * @param type The {@link javax.enterprise.inject.spi.AnnotatedType} to add for later scanning
+     * @throws IllegalStateException if called outside of the observer method invocation
      */
     public void addAnnotatedType(AnnotatedType<?> type, String id);
 

--- a/api/src/main/java/javax/enterprise/inject/spi/BeforeBeanDiscovery.java
+++ b/api/src/main/java/javax/enterprise/inject/spi/BeforeBeanDiscovery.java
@@ -44,6 +44,7 @@ public interface BeforeBeanDiscovery {
      * </p>
      * 
      * @param qualifier The annotation to treat as a qualifier
+     * @throws IllegalStateException if called outside of the observer method invocation
      */
     public void addQualifier(Class<? extends Annotation> qualifier);
 
@@ -57,6 +58,7 @@ public interface BeforeBeanDiscovery {
      * </p>
      * 
      * @param qualifier The annotation to treat as a qualifier
+     * @throws IllegalStateException if called outside of the observer method invocation
      * @since 1.1
      */
     public void addQualifier(AnnotatedType<? extends Annotation> qualifier);
@@ -77,6 +79,7 @@ public interface BeforeBeanDiscovery {
      * @param normal Indicates if the scope is normal
      * @param passivating Indicates if the scope is {@linkplain javax.enterprise.inject.spi.PassivationCapable passivation
      *        capable}
+     * @throws IllegalStateException if called outside of the observer method invocation
      */
     public void addScope(Class<? extends Annotation> scopeType, boolean normal, boolean passivating);
 
@@ -94,6 +97,7 @@ public interface BeforeBeanDiscovery {
      * @param stereotype The annotation type to treat as a {@linkplain javax.enterprise.inject.Stereotype stereotype}
      * @param stereotypeDef An optional list of annotations defining the {@linkplain javax.enterprise.inject.Stereotype
      *        stereotype}
+     * @throws IllegalStateException if called outside of the observer method invocation
      */
     public void addStereotype(Class<? extends Annotation> stereotype, Annotation... stereotypeDef);
 
@@ -108,6 +112,7 @@ public interface BeforeBeanDiscovery {
      * </p>
      * 
      * @param bindingType The annotation type to treat as an interceptor binding type
+     * @throws IllegalStateException if called outside of the observer method invocation
      */
     public void addInterceptorBinding(AnnotatedType<? extends Annotation> bindingType);
 
@@ -123,6 +128,7 @@ public interface BeforeBeanDiscovery {
      * 
      * @param bindingType The annotation type to treat as an interceptor binding type
      * @param bindingTypeDef An optional list of annotations defining the {@linkplain Interceptor interceptor}
+     * @throws IllegalStateException if called outside of the observer method invocation
      * @since 1.1
      */
     public void addInterceptorBinding(Class<? extends Annotation> bindingType, Annotation... bindingTypeDef);
@@ -137,6 +143,7 @@ public interface BeforeBeanDiscovery {
      * This method is deprecated from CDI 1.1 and {@link #addAnnotatedType(AnnotatedType, String)} should be used instead.
      * </p>
      * 
+     * @throws IllegalStateException if called outside of the observer method invocation
      * @param type The {@link javax.enterprise.inject.spi.AnnotatedType} to add for later scanning
      */
     public void addAnnotatedType(AnnotatedType<?> type);
@@ -160,6 +167,7 @@ public interface BeforeBeanDiscovery {
      * 
      * @param type The {@link javax.enterprise.inject.spi.AnnotatedType} to add for later scanning
      * @param id The id of the annotated type
+     * @throws IllegalStateException if called outside of the observer method invocation
      * @since 1.1
      */
     public void addAnnotatedType(AnnotatedType<?> type, String id);

--- a/api/src/main/java/javax/enterprise/inject/spi/ProcessAnnotatedType.java
+++ b/api/src/main/java/javax/enterprise/inject/spi/ProcessAnnotatedType.java
@@ -51,6 +51,7 @@ public interface ProcessAnnotatedType<X> {
      * declared annotations.
      * 
      * @return the {@code AnnotatedType} object
+     * @throws IllegalStateException if called outside of the observer method invocation
      */
     public AnnotatedType<X> getAnnotatedType();
 
@@ -58,11 +59,13 @@ public interface ProcessAnnotatedType<X> {
      * Replaces the {@link javax.enterprise.inject.spi.AnnotatedType}.
      * 
      * @param type the new {@link javax.enterprise.inject.spi.AnnotatedType} object to use
+     * @throws IllegalStateException if called outside of the observer method invocation
      */
     public void setAnnotatedType(AnnotatedType<X> type);
 
     /**
      * Forces the container to ignore this type.
+     * @throws IllegalStateException if called outside of the observer method invocation
      */
     public void veto();
 }

--- a/api/src/main/java/javax/enterprise/inject/spi/ProcessBean.java
+++ b/api/src/main/java/javax/enterprise/inject/spi/ProcessBean.java
@@ -53,6 +53,7 @@ public interface ProcessBean<X> {
      * {@link javax.enterprise.inject.spi.AnnotatedField} representing the producer field.
      * 
      * @return the {@link javax.enterprise.inject.spi.AnnotatedType} for the bean being registered
+     * @throws IllegalStateException if called outside of the observer method invocation
      */
     public Annotated getAnnotated();
 
@@ -62,6 +63,7 @@ public interface ProcessBean<X> {
      * {@link javax.decorator.Decorator}.
      * 
      * @return the {@link javax.enterprise.inject.spi.Bean} object about to be registered
+     * @throws IllegalStateException if called outside of the observer method invocation     * 
      */
     public Bean<X> getBean();
 
@@ -70,6 +72,7 @@ public interface ProcessBean<X> {
      * complete.
      * 
      * @param t The definition error to register as a {@link java.lang.Throwable}
+     * @throws IllegalStateException if called outside of the observer method invocation
      */
     public void addDefinitionError(Throwable t);
 }

--- a/api/src/main/java/javax/enterprise/inject/spi/ProcessBeanAttributes.java
+++ b/api/src/main/java/javax/enterprise/inject/spi/ProcessBeanAttributes.java
@@ -24,11 +24,13 @@ public interface ProcessBeanAttributes<T> {
     /**
      * @return the {@link AnnotatedType} representing the managed bean class or session bean class, the {@link AnnotatedMethod}
      *         representing the producer field, or the {@link AnnotatedField} representing the producer field
+     * @throws IllegalStateException if called outside of the observer method invocation
      */
     public Annotated getAnnotated();
 
     /**
      * @return the {@link BeanAttributes} object that will be used by the container to manage instances of the bean
+     * @throws IllegalStateException if called outside of the observer method invocation
      */
     public BeanAttributes<T> getBeanAttributes();
 
@@ -36,6 +38,7 @@ public interface ProcessBeanAttributes<T> {
      * Replaces the {@link BeanAttributes}.
      * 
      * @param beanAttributes the new {@link BeanAttributes} to use
+     * @throws IllegalStateException if called outside of the observer method invocation
      */
     public void setBeanAttributes(BeanAttributes<T> beanAttributes);
 
@@ -44,11 +47,13 @@ public interface ProcessBeanAttributes<T> {
      * complete.
      * 
      * @param t the error to add
+     * @throws IllegalStateException if called outside of the observer method invocation
      */
     public void addDefinitionError(Throwable t);
 
     /**
      * Forces the container to ignore the bean.
+     * @throws IllegalStateException if called outside of the observer method invocation
      */
     public void veto();
 }

--- a/api/src/main/java/javax/enterprise/inject/spi/ProcessInjectionPoint.java
+++ b/api/src/main/java/javax/enterprise/inject/spi/ProcessInjectionPoint.java
@@ -26,6 +26,7 @@ public interface ProcessInjectionPoint<T, X> {
 
     /**
      * @return the InjectionPoint object that will be used by the container to perform injection
+     * @throws IllegalStateException if called outside of the observer method invocation
      */
     public InjectionPoint getInjectionPoint();
 
@@ -33,6 +34,7 @@ public interface ProcessInjectionPoint<T, X> {
      * Replaces the InjectionPoint.
      * 
      * @param injectionPoint the new injection point
+     * @throws IllegalStateException if called outside of the observer method invocation
      */
     public void setInjectionPoint(InjectionPoint injectionPoint);
 
@@ -41,6 +43,7 @@ public interface ProcessInjectionPoint<T, X> {
      * complete.
      * 
      * @param t the definition error
+     * @throws IllegalStateException if called outside of the observer method invocation
      */
     public void addDefinitionError(Throwable t);
 }

--- a/api/src/main/java/javax/enterprise/inject/spi/ProcessInjectionTarget.java
+++ b/api/src/main/java/javax/enterprise/inject/spi/ProcessInjectionTarget.java
@@ -51,6 +51,7 @@ public interface ProcessInjectionTarget<X> {
      * other Java EE component class supporting injection.
      * 
      * @return the {@link javax.enterprise.inject.spi.AnnotatedType} of the bean with an injection target
+     * @throws IllegalStateException if called outside of the observer method invocation
      */
     public AnnotatedType<X> getAnnotatedType();
 
@@ -59,6 +60,7 @@ public interface ProcessInjectionTarget<X> {
      * injection.
      * 
      * @return the {@link javax.enterprise.inject.spi.InjectionTarget} object which performs the injection
+     * @throws IllegalStateException if called outside of the observer method invocation
      */
     public InjectionTarget<X> getInjectionTarget();
 
@@ -66,6 +68,7 @@ public interface ProcessInjectionTarget<X> {
      * Replaces the {@link javax.enterprise.inject.spi.InjectionTarget} which performs injection for this target.
      * 
      * @param injectionTarget The new {@link javax.enterprise.inject.spi.InjectionTarget} to use
+     * @throws IllegalStateException if called outside of the observer method invocation
      */
     public void setInjectionTarget(InjectionTarget<X> injectionTarget);
 
@@ -74,6 +77,7 @@ public interface ProcessInjectionTarget<X> {
      * complete.
      * 
      * @param t A {@link java.lang.Throwable} representing the definition error
+     * @throws IllegalStateException if called outside of the observer method invocation
      */
     public void addDefinitionError(Throwable t);
 }

--- a/api/src/main/java/javax/enterprise/inject/spi/ProcessManagedBean.java
+++ b/api/src/main/java/javax/enterprise/inject/spi/ProcessManagedBean.java
@@ -34,6 +34,7 @@ public interface ProcessManagedBean<X> extends ProcessBean<X> {
      * Returns the {@link javax.enterprise.inject.spi.AnnotatedType} representing the bean class.
      * 
      * @return the {@link javax.enterprise.inject.spi.AnnotatedType} for the bean being registered
+     * @throws IllegalStateException if called outside of the observer method invocation
      */
     public AnnotatedType<X> getAnnotatedBeanClass();
 }

--- a/api/src/main/java/javax/enterprise/inject/spi/ProcessObserverMethod.java
+++ b/api/src/main/java/javax/enterprise/inject/spi/ProcessObserverMethod.java
@@ -42,6 +42,7 @@ public interface ProcessObserverMethod<T, X> {
      * The {@link javax.enterprise.inject.spi.AnnotatedMethod} representing the observer method.
      * 
      * @return the {@link javax.enterprise.inject.spi.AnnotatedMethod} representing the observer method
+     * @throws IllegalStateException if called outside of the observer method invocation
      */
     public AnnotatedMethod<X> getAnnotatedMethod();
 
@@ -51,6 +52,7 @@ public interface ProcessObserverMethod<T, X> {
      * 
      * @return the {@link javax.enterprise.inject.spi.ObserverMethod} object that will be used by the container to call the
      *         observer method
+     * @throws IllegalStateException if called outside of the observer method invocation
      */
     public ObserverMethod<T> getObserverMethod();
 
@@ -59,6 +61,7 @@ public interface ProcessObserverMethod<T, X> {
      * complete.
      * 
      * @param t A {@link java.lang.Throwable} representing the definition error
+     * @throws IllegalStateException if called outside of the observer method invocation
      */
     public void addDefinitionError(Throwable t);
 }

--- a/api/src/main/java/javax/enterprise/inject/spi/ProcessProducer.java
+++ b/api/src/main/java/javax/enterprise/inject/spi/ProcessProducer.java
@@ -52,6 +52,7 @@ public interface ProcessProducer<T, X> {
      * {@link javax.enterprise.inject.spi.AnnotatedMethod} representing the producer method.
      * 
      * @return the {@link javax.enterprise.inject.spi.AnnotatedMember} representing the producer
+     * @throws IllegalStateException if called outside of the observer method invocation
      */
     public AnnotatedMember<T> getAnnotatedMember();
 
@@ -60,6 +61,7 @@ public interface ProcessProducer<T, X> {
      * method or read the producer field.
      * 
      * @return the {@link javax.enterprise.inject.spi.Producer} invoker object used by the container
+     * @throws IllegalStateException if called outside of the observer method invocation
      */
     public Producer<X> getProducer();
 
@@ -68,6 +70,7 @@ public interface ProcessProducer<T, X> {
      * method or read the producer field.
      * 
      * @param producer the new {@link javax.enterprise.inject.spi.Producer} object to use
+     * @throws IllegalStateException if called outside of the observer method invocation
      */
     public void setProducer(Producer<X> producer);
 
@@ -76,6 +79,7 @@ public interface ProcessProducer<T, X> {
      * complete.
      * 
      * @param t The definition error to register as a {@link java.lang.Throwable}
+     * @throws IllegalStateException if called outside of the observer method invocation
      */
     public void addDefinitionError(Throwable t);
 }

--- a/api/src/main/java/javax/enterprise/inject/spi/ProcessProducerField.java
+++ b/api/src/main/java/javax/enterprise/inject/spi/ProcessProducerField.java
@@ -39,6 +39,7 @@ public interface ProcessProducerField<T, X> extends ProcessBean<X> {
      * Returns the {@link javax.enterprise.inject.spi.AnnotatedField} representing the producer field.
      * 
      * @return the {@link javax.enterprise.inject.spi.AnnotatedField} for the producer field being registered
+     * @throws IllegalStateException if called outside of the observer method invocation
      */
     public AnnotatedField<T> getAnnotatedProducerField();
 
@@ -47,6 +48,7 @@ public interface ProcessProducerField<T, X> extends ProcessBean<X> {
      * the producer field return type found on a disposal method.
      * 
      * @return the disposal method's {@link javax.enterprise.inject.spi.AnnotatedParameter}
+     * @throws IllegalStateException if called outside of the observer method invocation
      * @since 1.1
      */
     public AnnotatedParameter<T> getAnnotatedDisposedParameter();

--- a/api/src/main/java/javax/enterprise/inject/spi/ProcessProducerMethod.java
+++ b/api/src/main/java/javax/enterprise/inject/spi/ProcessProducerMethod.java
@@ -38,6 +38,7 @@ public interface ProcessProducerMethod<T, X> extends ProcessBean<X> {
      * Returns the {@link javax.enterprise.inject.spi.AnnotatedMethod} representing the producer method.
      * 
      * @return the {@link javax.enterprise.inject.spi.AnnotatedMethod} for the producer method being registered
+     * @throws IllegalStateException if called outside of the observer method invocation
      */
     public AnnotatedMethod<T> getAnnotatedProducerMethod();
 
@@ -46,6 +47,7 @@ public interface ProcessProducerMethod<T, X> extends ProcessBean<X> {
      * the producer method return type found on a disposal method.
      * 
      * @return the disposal method's {@link javax.enterprise.inject.spi.AnnotatedParameter}
+     * @throws IllegalStateException if called outside of the observer method invocation
      */
     public AnnotatedParameter<T> getAnnotatedDisposedParameter();
 }

--- a/api/src/main/java/javax/enterprise/inject/spi/ProcessSessionBean.java
+++ b/api/src/main/java/javax/enterprise/inject/spi/ProcessSessionBean.java
@@ -42,6 +42,7 @@ public interface ProcessSessionBean<X> extends ProcessManagedBean<Object> {
      * Returns the EJB name of the session bean.
      * 
      * @return the name of the EJB
+     * @throws IllegalStateException if called outside of the observer method invocation
      */
     public String getEjbName();
 
@@ -49,6 +50,7 @@ public interface ProcessSessionBean<X> extends ProcessManagedBean<Object> {
      * Returns a {@link javax.enterprise.inject.spi.SessionBeanType} representing the kind of session bean.
      * 
      * @return the {@link javax.enterprise.inject.spi.SessionBeanType}
+     * @throws IllegalStateException if called outside of the observer method invocation
      */
     public SessionBeanType getSessionBeanType();
 }

--- a/api/src/main/java/javax/enterprise/inject/spi/ProcessSyntheticAnnotatedType.java
+++ b/api/src/main/java/javax/enterprise/inject/spi/ProcessSyntheticAnnotatedType.java
@@ -3,7 +3,9 @@ package javax.enterprise.inject.spi;
 /**
  * <p>
  * The container fires an event of this type for each Java class or interface added by
- * {@link BeforeBeanDiscovery#addAnnotatedType(AnnotatedType)}.
+ * {@link BeforeBeanDiscovery#addAnnotatedType(AnnotatedType)}, 
+ * {@link BeforeBeanDiscovery#addAnnotatedType(AnnotatedType, String)} or 
+ * {@link javax.enterprise.inject.spi.AfterTypeDiscovery#addAnnotatedType(AnnotatedType, String)}
  * </p>
  * <p>
  * Any observer of this event is permitted to wrap and/or replace the {@link javax.enterprise.inject.spi.AnnotatedType}. The
@@ -37,6 +39,7 @@ public interface ProcessSyntheticAnnotatedType<X> extends ProcessAnnotatedType<X
      * Get the extension instance which added the {@link AnnotatedType} for which this event is being fired.
      * 
      * @return the extension instance
+     * @throws IllegalStateException if called outside of the observer method invocation
      */
     public Extension getSource();
 }

--- a/spec/src/main/doc/spi.asciidoc
+++ b/spec/src/main/doc/spi.asciidoc
@@ -774,6 +774,8 @@ Observer methods of these events must belong to _extensions_. An extension is a 
 public interface Extension {}
 ----
 
+If any method on the event object is called outside of the observer method invocation, an +IllegalStateException+ is thrown.
+
 Service providers may have observer methods, which may observe any event, including any container lifecycle event, and obtain an injected +BeanManager+ reference. Any decorators associated with +BeanManager+ will not be applied. If other beans are injected into an extension's observer methods, non-portable behavior results. An extension may use +BeanManager.fireEvent()+ to deliver events to observer methods defined on extensions. The container is not required to deliver events fired during application initialization to observer methods defined on beans.
 
 The container instantiates a single instance of each extension at the beginning of the application initialization process and maintains a reference to it until the application shuts down. The container delivers event notifications to this instance by calling its observer methods.
@@ -814,6 +816,8 @@ void beforeBeanDiscovery(@Observes BeforeBeanDiscovery event) { ... }
 
 If any observer method of the +BeforeBeanDiscovery+ event throws an exception, the exception is treated as a definition error by the container.
 
+If any +BeforeBeanDiscovery+ method is called outside of the observer method invocation, an +IllegalStateException+ is thrown.
+
 [[atd]]
 
 ==== +AfterTypeDiscovery+ event
@@ -846,6 +850,8 @@ void afterTypeDiscovery(@Observes AfterTypeDiscovery event) { ... }
 
 
 If any observer method of a +AfterTypeDiscovery+ event throws an exception, the exception is treated as a definition error by the container.
+
+If any +AfterTypeDiscovery+ method is called outside of the observer method invocation, an +IllegalStateException+ is thrown.
 
 
 [[abd]]
@@ -884,6 +890,8 @@ void afterBeanDiscovery(@Observes AfterBeanDiscovery event, BeanManager manager)
 
 If any observer method of the +AfterBeanDiscovery+ event throws an exception, the exception is treated as a definition error by the container.
 
+If any +AfterBeanDiscovery+ method is called outside of the observer method invocation, an +IllegalStateException+ is thrown.
+
 [[adv]]
 
 ==== +AfterDeploymentValidation+ event
@@ -908,6 +916,8 @@ void afterDeploymentValidation(@Observes AfterDeploymentValidation event, BeanMa
 ----
 
 If any observer method of the +AfterDeploymentValidation+ event throws an exception, the exception is treated as a deployment problem by the container.
+
+If any +AfterDeploymentValidation+ method is called outside of the observer method invocation, an +IllegalStateException+ is thrown.
 
 The container must not allow any request to be processed by the deployment until all observers of this event return.
 
@@ -982,6 +992,8 @@ For example, the following observer decorates the +AnnotatedType+ for every clas
 
 If any observer method of a +ProcessAnnotatedType+ event throws an exception, the exception is treated as a definition error by the container.
 
+If any +ProcessAnnotatedType+ method is called outside of the observer method invocation, an +IllegalStateException+ is thrown.
+
 [[pip]]
 
 ==== +ProcessInjectionPoint+ event
@@ -1007,6 +1019,8 @@ public interface ProcessInjectionPoint<T, X> {
 Any observer of this event is permitted to wrap and/or replace the +InjectionPoint+. The container must use the final value of this property, after all observers have been called, whenever it performs injection upon the injection point.
 
 If any observer method of a +ProcessInjectionPoint+ event throws an exception, the exception is treated as a definition error by the container.
+
+If any +ProcessInjectionPoint+ method is called outside of the observer method invocation, an +IllegalStateException+ is thrown.
 
 [[pit]]
 
@@ -1045,6 +1059,8 @@ For example, this observer decorates the +InjectionTarget+ for all servlets.
 
 If any observer method of a +ProcessInjectionTarget+ event throws an exception, the exception is treated as a definition error by the container.
 
+If any +ProcessInjectionTarget+ method is called outside of the observer method invocation, an +IllegalStateException+ is thrown.
+
 [[pp]]
 
 ==== +ProcessProducer+ event
@@ -1081,6 +1097,8 @@ void decorateEntityManager(@Observes ProcessProducer<?, EntityManager> pp) {
 ----
 
 If any observer method of a +ProcessProducer+ event throws an exception, the exception is treated as a definition error by the container.
+
+If any +ProcessProducer+ method is called outside of the observer method invocation, an +IllegalStateException+ is thrown.
 
 [[pba]]
 
@@ -1119,6 +1137,8 @@ Any observer of this event is permitted to wrap and/or replace the +BeanAttribut
 Any bean which has its bean attributes altered must have it's definition validated during deployment validation.
 
 If any observer method of a +ProcessBeanAttributes+ event throws an exception, the exception is treated as a definition error by the container.
+
+If any +ProcessBeanAttributes+ method is called outside of the observer method invocation, an +IllegalStateException+ is thrown.
 
 [[pb]]
 
@@ -1198,6 +1218,8 @@ public interface ProcessProducerField<T, X>
 
 If any observer method of a +ProcessBean+ event throws an exception, the exception is treated as a definition error by the container.
 
+If any +ProcessBean+ method is called outside of the observer method invocation, an +IllegalStateException+ is thrown.
+
 [[pom]]
 
 ==== +ProcessObserverMethod+ event
@@ -1221,4 +1243,6 @@ public interface ProcessObserverMethod<T, X> {
 
 
 If any observer method of a +ProcessObserverMethod+ event throws an exception, the exception is treated as a definition error by the container.
+
+If any +ProcessObserverMethod+ method is called outside of the observer method invocation, an +IllegalStateException+ is thrown.
 


### PR DESCRIPTION
Introduce the general rule
Put the rule on BeforeBeanDiscovery before going general
