### PR TITLE
CDI-430 Revise the description of container lifecycle ordering during application initialization

### DIFF
--- a/spec/src/main/doc/packagingdeployment.asciidoc
+++ b/spec/src/main/doc/packagingdeployment.asciidoc
@@ -79,9 +79,9 @@ When an application is started, the container performs the following steps:
 
 * First, the container must search for service providers for the service +javax.enterprise.inject.spi.Extension+ defined in <<init_events>>, instantiate a single instance of each service provider, and search the service provider class for observer methods of initialization events.
 * Next, the container must fire an event of type +BeforeBeanDiscovery+, as defined in <<bbd>>.
-* Next, the container must perform type discovery. Additionally, for every type discovered the container must fire an event of type +ProcessAnnotatedType+, as defined in <<pat>>.
+* Next, the container must perform type discovery, as defined in <<type_discovery_steps>>.
 * Next, the container must fire an event of type +AfterTypeDiscovery+, as defined in <<atd>>.
-* Next, the container must perform bean discovery, and abort initialization of the application if any definition errors exist, as defined in <<exceptions>>. Additionally, for every Java EE component class supporting injection that may be instantiated by the container at runtime, the container must create an +InjectionTarget+ for the class, as defined in <<injectiontarget>>, and fire an event of type +ProcessInjectionTarget+, as defined in <<pit>>.
+* Next, the container must perform bean discovery, as defined in <<bean_discovery_steps>>.
 * Next, the container must fire an event of type +AfterBeanDiscovery+, as defined in <<abd>>, and abort initialization of the application if any observer registers a definition error.
 * Next, the container must detect deployment problems by validating bean dependencies and specialization and abort initialization of the application if any deployment problems exist, as defined in <<exceptions>>.
 * Next, the container must fire an event of type +AfterDeploymentValidation+, as defined in <<adv>>, and abort initialization of the application if any observer registers a deployment problem.
@@ -103,6 +103,14 @@ When an application is stopped, the container performs the following steps:
 === Bean discovery
 
 The container automatically discovers managed beans (according to the rules of <<what_classes_are_beans>>) and session beans in bean archives and searches the bean classes for producer methods, producer fields, disposer methods and observer methods.
+
+* First the container check existing _exclude filters_ to skip filtered types in discovery,
+* then the container discovers types,
+* finally the container discovers beans.
+
+[[exclude_filters]]
+
+==== Exclude filters
 
 Exclude filters are defined by +<exclude>+ elements in the +beans.xml+ for the bean archive as children of the +<scan>+ element. By default an exclude filter is active. If the exclude filter definition contains:
 
@@ -150,29 +158,42 @@ For example, consider the follow +beans.xml+ file:
 
 The first exclude filter will exclude all classes in +com.acme.rest+ package. The second exclude filter will exclude all classes in the +com.acme.faces+ package, and any subpackages, but only if JSF is not available. The third exclude filter will exclude all classes in the +com.acme.verbose+ package if the system property +verbosity+ has the value +low+. The fourth exclude filter will exclude all classes in the +com.acme.ejb+ package, and any subpackages if the system property +exclude-ejbs+ is set (with any value).
 
+
+[[type_discovery_steps]]
+
+==== Type discovery steps
+
 First the container must discover types. The container discovers:
 
 * each Java class, interface (excluding the special kind of interface declaration _annotation type_) or enum deployed in an explicit bean archive, and
 * each Java class with a bean defining annotation in an implicit bean archive.
 * each session bean
 
-that is not excluded from discovery.
+that is not excluded from discovery by an _exclude filter_ as defined in <<exclude_filters>>.
 
 Then, for every type discovered the container must create an +AnnotatedType+ representing the type and fire an event of type +ProcessAnnotatedType+, as defined in <<pat>>.
 
-If an extension calls +BeforeBeanDiscovery.addAnnotatedType()+ or +AfterTypeDiscovery.addAnnotatedType()+, the type passed must be added to the set of discovered types.
+If an extension calls +BeforeBeanDiscovery.addAnnotatedType()+ or +AfterTypeDiscovery.addAnnotatedType()+, the type passed must be added to the set of discovered types and the container must fire an event of type +ProcessSyntheticAnnotatedType+ for every type added, as defined in <<pat>>+
 
-Then, for every type in the set of discovered types, the container must:
+[[bean_discovery_steps]]
+
+==== Bean discovery steps
+
+For every type in the set of discovered types defined in <<type_discovery_steps>>, the container must:
 
 * inspect the type metadata to determine if it is a bean or other Java EE component class supporting injection, and then
 * detect definition errors by validating the class and its metadata, and then
+* if the class is a managed bean, session bean, or other Java EE component class supporting injection, create an +InjectionPoint+ for each injection point in the class, as defined in <<injection_point>>, and fire an event of type +ProcessInjectionPoint+, as defined in <<pip>>, and then
 * if the class is a managed bean, session bean, or other Java EE component class supporting injection, create an +InjectionTarget+ for the class, as defined in <<injectiontarget>>, and fire an event of type +ProcessInjectionTarget+, as defined in <<pit>>, and then
-* if the class is an enabled bean, interceptor or decorator, create a +Bean+ object that implements the rules defined in <<managed_bean_lifecycle>>, <<stateful_lifecycle>> or <<stateless_lifecycle>>, and fire an event which is a subtype of +ProcessBean+, as defined in <<pb>>.
+* if the class is an enabled bean, interceptor or decorator, create a +BeanAttributes+ as defined in <<bean>>, and fire of type +ProcessBeanAttributes+, as defined in <<pba>>, and then
+* if the class is an enabled bean, interceptor or decorator and if +ProcessBeanAttributes.veto()+ wasn't called in previous step, create a +Bean+ object, as defined in <<bean>>, that implements the rules defined in <<managed_bean_lifecycle>>, <<stateful_lifecycle>> or <<stateless_lifecycle>>, and fire an event which is a subtype of +ProcessBean+, as defined in <<pb>>.
 
-The container determines which alternatives, interceptors and decorators are enabled, according to the rules defined in <<enablement>>, <<enabled_interceptors>> and <<enabled_decorators>>. For each enabled bean, the container must search the class for producer methods and fields, including resources, and for each producer method or field:
+Then, the container determines which alternatives, interceptors and decorators are enabled, according to the rules defined in <<enablement>>, <<enabled_interceptors>> and <<enabled_decorators>>.
+For each enabled bean, the container must search the class for producer methods and fields, as defined in <<producer_method>> and in <<producer_field>>), including resources, and for each producer:
 
 * create a +Producer+, as defined in <<injectiontarget>>, and fire an event of type +ProcessProducer+, as defined in <<pp>>, and then
-* if the producer method or field is enabled, create a +Bean+ object that implements the rules defined in <<producer_method_lifecycle>>, <<producer_field_lifecycle>> or <<resource_lifecycle>>, and fire an event which is a subtype of +ProcessBean+, as defined in <<pb>>.
+* if the producer method or field is enabled, create a +BeanAttributes+, and fire an event of type +ProcessBeanAttributes+, as defined in <<pba>>, and then
+* if the producer method or field is enabled and if +ProcessBeanAttributes.veto()+ wasn't called in previous step, create a +Bean+ object that implements the rules defined in <<producer_method_lifecycle>>, <<producer_field_lifecycle>> or <<resource_lifecycle>>, and fire an event which is a subtype of +ProcessBean+, as defined in <<pb>>.
 
 For each enabled bean, the container must search the class for observer methods, and for each observer method:
 

--- a/spec/src/main/doc/spi.asciidoc
+++ b/spec/src/main/doc/spi.asciidoc
@@ -782,6 +782,25 @@ The container instantiates a single instance of each extension at the beginning 
 
 For each service provider, the container must provide a bean of scope +@ApplicationScoped+ and qualifier +@Default+, supporting injection of a reference to the service provider instance. The bean types of this bean include the class of the service provider and all superclasses and interfaces.
 
+Lifecycle events described below can be grouped in to two categories:
+
+* Application lifecycle events, that are fired once:
+ ** BeforeBeanDiscovery
+ ** AfterTypeDiscovery
+ ** AfterBeanDiscovery
+ ** AfterDeploymentValidation
+ ** BeforeShutdown
+* Bean discovery events, that are fired multiple times:
+ ** ProcessAnnotatedType
+ ** ProcessInjectionPoint
+ ** ProcessInjectionTarget
+ ** ProcessBeanAttributes
+ ** ProcessBean
+ ** ProcessProducer
+ ** ProcessObserverMethod
+
+Note that the chronological order of these events is specified in <<initialization>>.
+ 
 [[bbd]]
 
 ==== +BeforeBeanDiscovery+ event
@@ -1061,45 +1080,6 @@ If any observer method of a +ProcessInjectionTarget+ event throws an exception, 
 
 If any +ProcessInjectionTarget+ method is called outside of the observer method invocation, an +IllegalStateException+ is thrown.
 
-[[pp]]
-
-==== +ProcessProducer+ event
-
-The container must fire an event for each producer method or field of each bean, including resources.
-
-The event object must be of type +javax.enterprise.inject.spi.ProcessProducer<T, X>+, where +T+ is the bean class of the bean that declares the producer method or field and +X+ is the return type of the producer method or the type of the producer field.
-
-[source, java]
-----
-public interface ProcessProducer<T, X> {
-    public AnnotatedMember<T> getAnnotatedMember();
-    public Producer<X> getProducer();
-    public void setProducer(Producer<X> producer);
-    public void addDefinitionError(Throwable t);
-}
-----
-
-* +getAnnotatedMember()+ returns the +AnnotatedField+ representing the producer field or the +AnnotatedMethod+ representing the producer method.
-* +getProducer()+ returns the +Producer+ object that will be used by the container to call the producer method or read the producer field.
-* +setProducer()+ replaces the +Producer+.
-* +addDefinitionError()+ registers a definition error with the container, causing the container to abort deployment after bean discovery is complete.
-
-
-Any observer of this event is permitted to wrap and/or replace the +Producer+. The container must use the final value of this property, after all observers have been called, whenever it calls the producer or disposer.
-
-For example, this observer decorates the +Producer+ for all producer methods and fields of type +EntityManager+.
-
-[source, java]
-----
-void decorateEntityManager(@Observes ProcessProducer<?, EntityManager> pp) {
-    pit.setProducer( decorate( pp.getProducer() ) );
-}
-----
-
-If any observer method of a +ProcessProducer+ event throws an exception, the exception is treated as a definition error by the container.
-
-If any +ProcessProducer+ method is called outside of the observer method invocation, an +IllegalStateException+ is thrown.
-
 [[pba]]
 
 ==== +ProcessBeanAttributes+ event
@@ -1219,6 +1199,45 @@ public interface ProcessProducerField<T, X>
 If any observer method of a +ProcessBean+ event throws an exception, the exception is treated as a definition error by the container.
 
 If any +ProcessBean+ method is called outside of the observer method invocation, an +IllegalStateException+ is thrown.
+
+[[pp]]
+
+==== +ProcessProducer+ event
+
+The container must fire an event for each producer method or field of each bean, including resources.
+
+The event object must be of type +javax.enterprise.inject.spi.ProcessProducer<T, X>+, where +T+ is the bean class of the bean that declares the producer method or field and +X+ is the return type of the producer method or the type of the producer field.
+
+[source, java]
+----
+public interface ProcessProducer<T, X> {
+    public AnnotatedMember<T> getAnnotatedMember();
+    public Producer<X> getProducer();
+    public void setProducer(Producer<X> producer);
+    public void addDefinitionError(Throwable t);
+}
+----
+
+* +getAnnotatedMember()+ returns the +AnnotatedField+ representing the producer field or the +AnnotatedMethod+ representing the producer method.
+* +getProducer()+ returns the +Producer+ object that will be used by the container to call the producer method or read the producer field.
+* +setProducer()+ replaces the +Producer+.
+* +addDefinitionError()+ registers a definition error with the container, causing the container to abort deployment after bean discovery is complete.
+
+
+Any observer of this event is permitted to wrap and/or replace the +Producer+. The container must use the final value of this property, after all observers have been called, whenever it calls the producer or disposer.
+
+For example, this observer decorates the +Producer+ for all producer methods and fields of type +EntityManager+.
+
+[source, java]
+----
+void decorateEntityManager(@Observes ProcessProducer<?, EntityManager> pp) {
+    pit.setProducer( decorate( pp.getProducer() ) );
+}
+----
+
+If any observer method of a +ProcessProducer+ event throws an exception, the exception is treated as a definition error by the container.
+
+If any +ProcessProducer+ method is called outside of the observer method invocation, an +IllegalStateException+ is thrown.
 
 [[pom]]
 


### PR DESCRIPTION
rewriting general lifecycle description and Bean Discovery detail.
In 11.5 summarized all event to stress the fact they're not presented in chronological order.
Break 12.4 in 3 subpart : filter, type discovery, bean discovery to be clearer.
Try to give a big picture of lifecycle in 12.2 and detail it 12.4.2 and 12.4.3.
