### PR TITLE
Change BeanManager treatment in CDI Lite

### DIFF
--- a/spec/src/main/asciidoc/core/beanmanager_lite.asciidoc
+++ b/spec/src/main/asciidoc/core/beanmanager_lite.asciidoc
@@ -10,7 +10,8 @@ It is available in {cdi_lite} environment, and therefore also in {cdi_full} envi
 `BeanManager` extends `BeanContainer` and provides additional features.
 It is only available in {cdi_full} environment.
 
-In {cdi_lite} environment, attempting to obtain a `BeanManager` or invoking methods on it results in non-portable behavior.
+In {cdi_lite} environment, obtaining a `BeanManager` is possible, but only methods inherited from `BeanContainer` may be invoked.
+Invoking `BeanManager` methods that are not inherited from `BeanContainer` results in non-portable behavior.
 
 [[beancontainer]]
 


### PR DESCRIPTION
Previously, the specification downright disallowed obtaining
a `BeanManager` in CDI Lite. This makes portability from CDI Full
to CDI Lite harder, which also manifests in the CDI TCK.

Wit this commit, CDI Lite applications may obtain a `BeanManager`,
but may only call methods inherited from `BeanContainer`.