### PR TITLE
Describe in more depth what kind of interception is supported in Lite.

### DIFF
--- a/spec/src/main/asciidoc/cdi-spec.asciidoc
+++ b/spec/src/main/asciidoc/cdi-spec.asciidoc
@@ -57,7 +57,7 @@ include::core/beanmanager_lite.asciidoc[]
 
 include::core/spi_lite.asciidoc[]
 
-include::core/packagingdeployment_lite.asciidoc[]
+include::core/packagingdeployment.asciidoc[]
 
 :leveloffset: -1
 

--- a/spec/src/main/asciidoc/core/interceptors.asciidoc
+++ b/spec/src/main/asciidoc/core/interceptors.asciidoc
@@ -5,10 +5,18 @@
 Managed beans support interception.
 _Interceptors_ are used to separate cross-cutting concerns from business logic.
 The Jakarta Interceptors specification defines the basic programming model and semantics, and how to associate interceptors with target classes.
-This specification defines various extensions to the Java Interceptors specification, including non-binding annotation values in interceptor resolution.
+This specification defines an extent to which {cdi_lite} supports Jakarta Interceptors specification, including extending it with non-binding annotation values in interceptor resolution.
 
-{cdi_lite} implementations are not required to support associating interceptors with classes and methods using the `@jakarta.interceptor.Interceptors` annotation.
-They are required to support interceptor binding annotations.
+{cdi_lite} implementations are required to support following forms of interception:
+
+* Interceptors declared on interceptor classes and associated with target class using interceptor binding annotations
+** `@AroundInvoke`, `@PostConstruct`, `@PreDestroy` and `@AroundConstruct` are all supported
+** Enablement and ordering of interceptors using `@Priority` annotation
+* `@PostConstruct` and `@PreDestroy` declared on target class (i.e. on a bean)
+
+Using other forms of interception results in non-portable behavior.
+
+{cdi_full} implementations are required to support all forms of interception, as described in <<interceptors_full>>.
 
 [[interceptor_bindings]]
 

--- a/spec/src/main/asciidoc/core/interceptors_full.asciidoc
+++ b/spec/src/main/asciidoc/core/interceptors_full.asciidoc
@@ -4,7 +4,16 @@
 
 This specification defines various extensions to the Jakarta Interceptors specification, including how to override the interceptor order defined by the `@Priority` annotation.
 
-{cdi_full} implementations are required to support the entire Jakarta Interceptors specification, including associating interceptors with classes and methods using the `@jakarta.interceptor.Interceptors` annotation.
+{cdi_full} implementations are required to support the entire Jakarta Interceptors specification, including:
+
+* associating interceptors with classes and methods using the `@jakarta.interceptor.Interceptors` annotation,
+* declaring `@AroundInvoke` interceptor methods on _target classes_ (i.e. on beans).
+
+Furthermore, {cdi_full} implementations are required to support additional features, including:
+
+* custom implementations of `Interceptor`,
+* usage of `InterceptionFactory` as described in <<interception_factory>>,
+* enablement and ordering of interceptors per bean archive via `beans.xml` as described in <<enabled_interceptors>>.
 
 [[binding_interceptor_to_bean_full]]
 


### PR DESCRIPTION
Originally, I wanted to add the table like we had in the issue but I decided against it to avoid drawing attention to many cases which are forbidden by either of specs.

Also fixed a broken link in `cdi-spec.asciidoc`, probably a remnant from other changes.

Fixes #545 