### PR TITLE
Remove the notion of version from Packaging and deployment for CDI Full

### DIFF
--- a/spec/src/main/asciidoc/core/packagingdeployment_full.asciidoc
+++ b/spec/src/main/asciidoc/core/packagingdeployment_full.asciidoc
@@ -24,7 +24,7 @@ Portable extensions may even integrate with the process of building the `Bean` o
 
 Bean classes of enabled beans must be deployed in _bean archives_.
 
-A bean archive has a _bean discovery mode_ of `all`, `annotated` or `none`. A bean archive which contains a `beans.xml` file with no version has a default bean discovery mode of `all`. A bean archive which contains a `beans.xml` file with version 1.1 (or later) must specify the `bean-discovery-mode` attribute. The default value for the attribute is `annotated`.
+A bean archive has a _bean discovery mode_ of `all`, `annotated` or `none`. A bean archive which contains non-empty `beans.xml` must specify the `bean-discovery-mode` attribute. The default value for the attribute is `annotated`.
 
 An archive which:
 
@@ -33,10 +33,7 @@ An archive which:
 
 is not a bean archive.
 
-An _explicit bean archive_ is an archive which contains a `beans.xml` file:
-
-* with a version number of `1.1` (or later), with the `bean-discovery-mode` of `all`, or,
-* with no version number.
+An _explicit bean archive_ is an archive which contains a `beans.xml` file with `bean-discovery-mode` of `all`.
 
 An _implicit bean archive_ is:
 


### PR DESCRIPTION
Earlier today me and @Ladicek discussed that there is a potential hole in between Lite and Full with regards to `beans.xml`.
You can have `beans.xml` that is not an empty file and declares the `<beans>` element but *does not* specify `version` and `bean-discovery-mode`.
Such archive would then end up with `annotated` discovery in Lite but with `all` in Full (due to not having a version).

This PR is a proposed fix for that.