### PR TITLE
Remove dependency on JTA API

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -135,7 +135,6 @@
 		<interceptor.api.version>2.1.0</interceptor.api.version>
 		<!-- These are only used in javadoc links -->
 		<ejb.api.version>4.0.0</ejb.api.version>
-		<transaction.api.version>2.0.0</transaction.api.version>
 
 		<maven.compiler.release>11</maven.compiler.release>
 		<maven-bundle-plugin.version>5.1.2</maven-bundle-plugin.version>
@@ -183,13 +182,6 @@
 				<artifactId>jakarta.interceptor-api</artifactId>
 				<version>${interceptor.api.version}</version>
 			</dependency>
-
-			<!-- Only for javadoc references -->
-			<dependency>
-				<groupId>jakarta.transaction</groupId>
-				<artifactId>jakarta.transaction-api</artifactId>
-				<version>${transaction.api.version}</version>
-			</dependency>
 		</dependencies>
 	</dependencyManagement>
 
@@ -223,12 +215,6 @@
 		<dependency>
 			<groupId>jakarta.inject</groupId>
 			<artifactId>jakarta.inject-api</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>jakarta.transaction</groupId>
-			<artifactId>jakarta.transaction-api</artifactId>
-			<scope>provided</scope>
 		</dependency>
 
 		<dependency>

--- a/api/src/main/java/jakarta/enterprise/event/TransactionPhase.java
+++ b/api/src/main/java/jakarta/enterprise/event/TransactionPhase.java
@@ -25,8 +25,8 @@ package jakarta.enterprise.event;
  * Transactional observer methods are observer methods which receive event notifications during the before or after completion
  * phase of the transaction in which the event was fired. If no transaction is in progress when the event is fired, they are
  * notified at the same time as other observers.
- * If the transaction is in progress, but {@link jakarta.transaction.Synchronization} callback cannot be registered due to the transaction being already
- * marked for rollback or in state where {@link jakarta.transaction.Synchronization} callbacks cannot be registered, the {@link #BEFORE_COMPLETION},
+ * If the transaction is in progress, but {@code jakarta.transaction.Synchronization} callback cannot be registered due to the transaction being already
+ * marked for rollback or in state where {@code jakarta.transaction.Synchronization} callbacks cannot be registered, the {@link #BEFORE_COMPLETION},
  * {@link #AFTER_COMPLETION} and {@link #AFTER_FAILURE} observer methods are notified at the same time as other observers,
  * but {@link #AFTER_SUCCESS} observer methods get skipped.
  * </p>
@@ -51,8 +51,8 @@ public enum TransactionPhase {
      * </p>
      * <p>
      * Transactional observer will be notified if there is no transaction in progress, or the transaction is in progress,
-     * but {@link jakarta.transaction.Synchronization} callback cannot be registered due to the transaction being already
-     * marked for rollback or in state where {@link jakarta.transaction.Synchronization} callbacks cannot be registered.
+     * but {@code jakarta.transaction.Synchronization} callback cannot be registered due to the transaction being already
+     * marked for rollback or in state where {@code jakarta.transaction.Synchronization} callbacks cannot be registered.
      * </p>
      */
     BEFORE_COMPLETION,
@@ -63,8 +63,8 @@ public enum TransactionPhase {
      * </p>
      * <p>
      * Transactional observer will be notified if there is no transaction in progress, or the transaction is in progress,
-     * but {@link jakarta.transaction.Synchronization} callback cannot be registered due to the transaction being already
-     * marked for rollback or in state where {@link jakarta.transaction.Synchronization} callbacks cannot be registered.
+     * but {@code jakarta.transaction.Synchronization} callback cannot be registered due to the transaction being already
+     * marked for rollback or in state where {@code jakarta.transaction.Synchronization} callbacks cannot be registered.
      * </p>
      */
     AFTER_COMPLETION,
@@ -76,8 +76,8 @@ public enum TransactionPhase {
      * </p>
      * <p>
      * Transactional observer will be notified will also get invoked if there is no transaction in progress, or the transaction is in progress,
-     * but {@link jakarta.transaction.Synchronization} callback cannot be registered due to the transaction being already
-     * marked for rollback or in state where {@link jakarta.transaction.Synchronization} callbacks cannot be registered.
+     * but {@code jakarta.transaction.Synchronization} callback cannot be registered due to the transaction being already
+     * marked for rollback or in state where {@code jakarta.transaction.Synchronization} callbacks cannot be registered.
      * </p>
      */
     AFTER_FAILURE,


### PR DESCRIPTION
Fixes #608 

This is one of the ways to address it as we don't really need the dependency on JTA apart from javadoc of a single class.

(FYI @arjantijms)