### PR TITLE
Make sure CDI and BuildServicesResolves both guard against repeated i…

### DIFF
--- a/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/BuildServicesResolver.java
+++ b/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/BuildServicesResolver.java
@@ -12,7 +12,6 @@ package jakarta.enterprise.inject.build.compatible.spi;
 
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.Objects;
 import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
 import java.util.Set;
@@ -76,8 +75,17 @@ public final class BuildServicesResolver {
      * this class will no longer attempt to look it up using service loader.
      *
      * @param instance a {@link BuildServices} instance that should be used, must not be {@code null}
+     * @throws IllegalArgumentException if the provided argument is null
+     * @throws IllegalStateException if the {@link BuildServices} are already set
      */
     public static void setBuildServices(BuildServices instance) {
-        configuredBuildServices = Objects.requireNonNull(instance, "BuildServices instance must not be null");
+        if (instance == null) {
+            throw new IllegalArgumentException("BuildServices instance must not be null");
+        }
+        if (configuredBuildServices != null) {
+            configuredBuildServices = instance;
+        } else {
+            throw new IllegalStateException("BuildServices cannot be set repeatedly. Existing BuildServices are " + configuredBuildServices);
+        }
     }
 }

--- a/api/src/main/java/jakarta/enterprise/inject/spi/CDI.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/CDI.java
@@ -68,7 +68,7 @@ public abstract class CDI<T> implements Instance<T> {
     /**
      *
      * Obtain the {@link CDIProvider} the user set with {@link #setCDIProvider(CDIProvider)} or the last returned
-     * {@link CDIProvider} if it returns valid CDI container. Otherwise use the serviceloader to retrieve the
+     * {@link CDIProvider} if it returns valid CDI container. Otherwise, use service loader mechanism to retrieve the
      * {@link CDIProvider} with the highest priority.
      *
      * @return the {@link CDIProvider} set by user or retrieved by serviceloader
@@ -118,13 +118,17 @@ public abstract class CDI<T> implements Instance<T> {
      *
      * @param provider the provider to use
      * @throws IllegalStateException if the {@link CDIProvider} is already set
+     * @throws IllegalArgumentException if the provided argument is null
      */
     public static void setCDIProvider(CDIProvider provider) {
-        if (provider != null) {
+        if (provider == null) {
+            throw new IllegalArgumentException("CDIProvider must not be null");
+        }
+        if (configuredProvider != null) {
             providerSetManually = true;
             configuredProvider = provider;
         } else {
-            throw new IllegalStateException("CDIProvider must not be null");
+            throw new IllegalStateException("CDIProvider cannot be set repeatedly. Existing provider is " + configuredProvider);
         }
     }
 


### PR DESCRIPTION
…nvocations of set method

Fixes #618 

Both APIs now behave equally and guard firstly against `null` value and then against attempts to re-set previously configured value.

This is potentially breaking change and as such should only be part of next bigger release.