### PR TITLE
Improve section numbering

### DIFF
--- a/spec/src/main/asciidoc/cdi-spec.asciidoc
+++ b/spec/src/main/asciidoc/cdi-spec.asciidoc
@@ -33,9 +33,10 @@ include::architecture.asciidoc[]
 [[part_1]]
 = Part I - Core CDI
 
-== {cdi_lite}
+include::core/core_structure.adoc[]
 
-:leveloffset: +1
+[[part_1a]]
+= Part I.A - {cdi_lite}
 
 include::core/definition.asciidoc[]
 
@@ -59,11 +60,8 @@ include::core/spi_lite.asciidoc[]
 
 include::core/packagingdeployment.asciidoc[]
 
-:leveloffset: -1
-
-== {cdi_full}
-
-:leveloffset: +1
+[[part_1b]]
+= Part I.B - {cdi_full}
 
 include::core/definition_full.asciidoc[]
 
@@ -84,8 +82,6 @@ include::core/events_full.asciidoc[]
 include::core/spi_full.asciidoc[]
 
 include::core/packagingdeployment_full.asciidoc[]
-
-:leveloffset: -1
 
 [[part_2]]
 = Part II - CDI in Java SE

--- a/spec/src/main/asciidoc/core/core_structure.adoc
+++ b/spec/src/main/asciidoc/core/core_structure.adoc
@@ -1,0 +1,10 @@
+:numbered!:
+
+== Structure
+
+The Core CDI specification has two subparts:
+
+* {cdi_lite} specification which contains a subset of CDI features and which can be implemented in more restricted environments; this is part of the Jakarta EE Core Profile;
+* {cdi_full} specification that builds on top of Lite and adds all advanced CDI features; this is the classic CDI platform that is part of the Jakarta EE Web Profile and Jakarta EE Platform.
+
+:numbered:

--- a/spec/src/main/asciidoc/core/definition_full.asciidoc
+++ b/spec/src/main/asciidoc/core/definition_full.asciidoc
@@ -1,7 +1,8 @@
-[[concepts_full]]
-
+[partintro]
+--
 {cdi_full} contains all the functionality defined in {cdi_lite} and adds some additional features such as specialization, decorators, session scope or conversation scope.
 Some of these concepts were briefly mentioned in the previous {cdi_lite} chapter and this section of specification defines them in depth.
+--
 
 [[scopes_full]]
 

--- a/spec/src/main/asciidoc/preface.asciidoc
+++ b/spec/src/main/asciidoc/preface.asciidoc
@@ -15,9 +15,9 @@ include::license-{license}.asciidoc[]
 This document is organized in 4 parts:
 
 * An introduction (this part), which is not part of the specification but introduces CDI concepts and gives examples.
-* Core CDI specification: <<part_1>>. This part has two sections:
-** {cdi_lite} specification which contains a subset of CDI features and which can be implemented in more restricted environments;
-** {cdi_full} specification that builds on top of Lite and adds all advanced CDI features; this is the standard Jakarta EE CDI platform.
+* Core CDI specification: <<part_1>>. This part has two subparts:
+** {cdi_lite} specification: <<part_1a>>;
+** {cdi_full} specification: <<part_1b>>.
 * Specific CDI features for Java SE: <<part_2>>.
 * Specific CDI features for Jakarta EE: <<part_3>>.
 


### PR DESCRIPTION
CDI specification up to version 3.0 used to have the sections numbered in a friendly way:

1. Architecture
2. Concepts
3. Programming model

And so on. With CDI 4.0 and the split to Lite and Full, sections were renumbered in a more ugly fashion:

1. Architecture
2. CDI Lite
2.1. Concepts
2.2. Programming model
4. CDI Full

Note that this numbering is different from the TCK Audit tool expectations and hence the TCK Audit reports are incorrect.

This commit restores the original numbering, which is more user-friendly and also conforms to the expectations of the TCK Audit tool.