### PR TITLE
Method invokers

### DIFF
--- a/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/BeanInfo.java
+++ b/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/BeanInfo.java
@@ -10,6 +10,7 @@
 
 package jakarta.enterprise.inject.build.compatible.spi;
 
+import jakarta.enterprise.invoke.InvokerBuilder;
 import jakarta.enterprise.lang.model.AnnotationInfo;
 import jakarta.enterprise.lang.model.declarations.ClassInfo;
 import jakarta.enterprise.lang.model.declarations.FieldInfo;
@@ -161,6 +162,25 @@ public interface BeanInfo {
      * @return immutable collection of injection points, never {@code null}
      */
     Collection<InjectionPointInfo> injectionPoints();
+
+    /**
+     * Returns a new {@link InvokerBuilder} for given method. The builder eventually produces
+     * an opaque representation of the invoker for the given method.
+     * <p>
+     * The {@code method} must be declared on the bean class or inherited from a supertype
+     * of the bean class of this bean, otherwise an exception is thrown.
+     * <p>
+     * If an invoker may not be obtained for given {@code method} as described
+     * in {@link jakarta.enterprise.invoke.Invoker Invoker}, an exception is thrown.
+     * <p>
+     * If this method is called outside the {@code @Registration} phase, an exception is thrown.
+     *
+     * @param method method of this bean, must not be {@code null}
+     * @return the invoker builder, never {@code null}
+     * @since 4.1
+     */
+    // TODO we may want to introduce another entrypoint for this operation
+    InvokerBuilder<InvokerInfo> createInvoker(MethodInfo method);
 
     // ---
 

--- a/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/InvokerInfo.java
+++ b/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/InvokerInfo.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2022 Red Hat and others
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package jakarta.enterprise.inject.build.compatible.spi;
+
+import jakarta.enterprise.invoke.Invoker;
+import jakarta.enterprise.lang.model.declarations.MethodInfo;
+
+/**
+ * Opaque token that stands in for an invoker registered using {@link BeanInfo#createInvoker(MethodInfo)}.
+ * It can only be used to materialize an {@link Invoker} in a synthetic component; see
+ * {@link SyntheticBeanBuilder#withParam(String, InvokerInfo) SyntheticBeanBuilder.withParam()} or
+ * {@link SyntheticObserverBuilder#withParam(String, InvokerInfo) SyntheticObserverBuilder.withParam()}.
+ *
+ * @since 4.1
+ */
+public interface InvokerInfo {
+}

--- a/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/Parameters.java
+++ b/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/Parameters.java
@@ -10,6 +10,8 @@
 
 package jakarta.enterprise.inject.build.compatible.spi;
 
+import jakarta.enterprise.invoke.Invoker;
+
 /**
  * A {@code String}-keyed parameter map. The parameter mappings are defined
  * by a synthetic component builder. The CDI container passes the parameter map
@@ -40,13 +42,16 @@ package jakarta.enterprise.inject.build.compatible.spi;
  * <p>
  * Annotation-typed parameters are available as instances of the annotation type,
  * even if an instance of {@code AnnotationInfo} was passed to the builder.
+ * <p>
+ * Invoker-typed parameters are available as instances of {@link Invoker}, even though
+ * an instance of {@code InvokerInfo} was passed to the builder.
  */
 public interface Parameters {
     /**
      * Returns the value of a parameter with given {@code key}. The value is expected to be of given {@code type}.
      *
-     * @param key the parameter key; must not be {@code null}
-     * @param type the parameter type; must not be {@code null}
+     * @param key the parameter key, must not be {@code null}
+     * @param type the parameter type, must not be {@code null}
      * @param <T> the parameter type
      * @return the parameter value, or {@code null} if parameter with given {@code key} does not exist
      * @throws ClassCastException if the parameter exists, but is of a different type
@@ -57,8 +62,8 @@ public interface Parameters {
      * Returns the value of a parameter with given {@code key}. The value is expected to be of given {@code type}.
      * If the parameter does not exist, returns {@code defaultValue}.
      *
-     * @param key the parameter key; must not be {@code null}
-     * @param type the parameter type; must not be {@code null}
+     * @param key the parameter key, must not be {@code null}
+     * @param type the parameter type, must not be {@code null}
      * @param defaultValue the value to return if parameter with given {@code key} does not exist
      * @param <T> the parameter type
      * @return the parameter value, or {@code defaultValue} if parameter with given {@code key} does not exist

--- a/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/SyntheticBeanBuilder.java
+++ b/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/SyntheticBeanBuilder.java
@@ -406,6 +406,36 @@ public interface SyntheticBeanBuilder<T> {
     SyntheticBeanBuilder<T> withParam(String key, Annotation[] value);
 
     /**
+     * Adds an invoker-valued parameter to the parameter map. The parameter map is passed
+     * to the {@linkplain SyntheticBeanCreator creation} and {@linkplain SyntheticBeanDisposer destruction}
+     * functions when a bean instance is created/destroyed.
+     * <p>
+     * When looked up from the parameter map in the creation/destruction function, the value will be
+     * an instance of {@link jakarta.enterprise.invoke.Invoker Invoker}, <em>not</em> an {@code InvokerInfo}.
+     *
+     * @param key the parameter key, must not be {@code null}
+     * @param value the parameter value
+     * @return this {@code SyntheticBeanBuilder}
+     * @since 4.1
+     */
+    SyntheticBeanBuilder<T> withParam(String key, InvokerInfo value);
+
+    /**
+     * Adds an invoker array-valued parameter to the parameter map. The parameter map is passed
+     * to the {@linkplain SyntheticBeanCreator creation} and {@linkplain SyntheticBeanDisposer destruction}
+     * functions when a bean instance is created/destroyed.
+     * <p>
+     * When looked up from the parameter map in the creation/destruction function, the values will be
+     * instances of {@link jakarta.enterprise.invoke.Invoker Invoker}, <em>not</em> {@code InvokerInfo}.
+     *
+     * @param key the parameter key, must not be {@code null}
+     * @param value the parameter value
+     * @return this {@code SyntheticBeanBuilder}
+     * @since 4.1
+     */
+    SyntheticBeanBuilder<T> withParam(String key, InvokerInfo[] value);
+
+    /**
      * Sets the class of the synthetic bean {@linkplain SyntheticBeanCreator creation} function.
      * CDI container will create an instance of the creation function every time when it needs
      * to obtain an instance of the synthetic bean. The class must be {@code public} and have

--- a/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/SyntheticObserverBuilder.java
+++ b/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/SyntheticObserverBuilder.java
@@ -335,6 +335,34 @@ public interface SyntheticObserverBuilder<T> {
     SyntheticObserverBuilder<T> withParam(String key, Annotation[] value);
 
     /**
+     * Adds an invoker-valued parameter to the parameter map. The parameter map is passed
+     * to the {@linkplain SyntheticObserver event notification} function when the event is fired.
+     * <p>
+     * When looked up from the parameter map in the event notification function, the value will be
+     * an instance of {@link jakarta.enterprise.invoke.Invoker Invoker}, <em>not</em> an {@code InvokerInfo}.
+     *
+     * @param key the parameter key, must not be {@code null}
+     * @param value the parameter value
+     * @return this {@code SyntheticBeanBuilder}
+     * @since 4.1
+     */
+    SyntheticObserverBuilder<T> withParam(String key, InvokerInfo value);
+
+    /**
+     * Adds an invoker array-valued parameter to the parameter map. The parameter map is passed
+     * to the {@linkplain SyntheticObserver event notification} function when the event is fired.
+     * <p>
+     * When looked up from the parameter map in the event notification function, the values will be
+     * instances of {@link jakarta.enterprise.invoke.Invoker Invoker}, <em>not</em> {@code InvokerInfo}.
+     *
+     * @param key the parameter key, must not be {@code null}
+     * @param value the parameter value
+     * @return this {@code SyntheticBeanBuilder}
+     * @since 4.1
+     */
+    SyntheticObserverBuilder<T> withParam(String key, InvokerInfo[] value);
+
+    /**
      * Sets the class of the synthetic observer {@linkplain SyntheticObserver event notification} function.
      * CDI container will create an instance of the event notification function every time when it needs
      * to notify the synthetic observer. The class must be {@code public} and have a {@code public}

--- a/api/src/main/java/jakarta/enterprise/inject/spi/ProcessManagedBean.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/ProcessManagedBean.java
@@ -15,6 +15,9 @@
  */
 package jakarta.enterprise.inject.spi;
 
+import jakarta.enterprise.invoke.Invoker;
+import jakarta.enterprise.invoke.InvokerBuilder;
+
 /**
  * <p>
  * The container fires an event of this type for each enabled managed bean, before registering the
@@ -38,4 +41,17 @@ public interface ProcessManagedBean<X> extends ProcessBean<X> {
      * @throws IllegalStateException if called outside of the observer method invocation
      */
     public AnnotatedType<X> getAnnotatedBeanClass();
+
+    /**
+     * Returns a new {@link InvokerBuilder} for given method. The builder eventually produces an invoker
+     * for the given method.
+     * <p>
+     * The {@code method} must be declared on the bean class or inherited from a supertype
+     * of the bean class of the bean being registered, otherwise an exception is thrown.
+     *
+     * @param method method of the bean being registered, must not be {@code null}
+     * @return the invoker builder, never {@code null}
+     * @since 4.1
+     */
+    public InvokerBuilder<Invoker<X, ?>> createInvoker(AnnotatedMethod<? super X> method);
 }

--- a/api/src/main/java/jakarta/enterprise/invoke/Invoker.java
+++ b/api/src/main/java/jakarta/enterprise/invoke/Invoker.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2022 Red Hat and others
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package jakarta.enterprise.invoke;
+
+/**
+ * Allows indirectly invoking a method that belongs to a managed bean (the <em>target method</em>).
+ * To invoke the method, the caller must provide all the arguments that the target method accepts,
+ * as well as the instance on which the target method is to be invoked, if it is not {@code static}.
+ * <p>
+ * Whenever a direct invocation of a method is a business method invocation, an indirect invocation
+ * of that method through an invoker is also a business method invocation.
+ * <p>
+ * Invoker implementations must be thread-safe. It is possible to use a single invoker instance
+ * to perform multiple independent invocations of the target method, possibly on different instances
+ * and with different arguments.
+ *
+ * <h2>Obtaining an invoker</h2>
+ *
+ * The CDI container allows {@linkplain InvokerBuilder building} an invoker for non-private
+ * methods declared on a managed bean class or inherited from a supertype. Attempting to build
+ * an invoker for a private method or a constructor of a managed bean class leads to a deployment
+ * problem. Attempting to build an invoker for a method of a class that is not a managed bean class
+ * or that is an interceptor or decorator class leads to a deployment problem.
+ * <p>
+ * Multiple managed beans may inherit a method from a common supertype. In that case, each bean
+ * conceptually has its own method and an invoker obtained for one bean may not be used to invoke
+ * the method on the other bean.
+ * <p>
+ * Using the {@link InvokerBuilder} is the only way to obtain an invoker. An {@code InvokerBuilder}
+ * can only be obtained in CDI portable extensions and build compatible extensions.
+ *
+ * <h2>Example</h2>
+ *
+ * To illustrate how invokers work, let's take a look at an example. Say that the following bean
+ * exists and has a method that you want to invoke indirectly:
+ *
+ * <pre>
+ * &#64;Dependent
+ * class MyService {
+ *     String hello(String name) {
+ *         return "Hello " + name + "!";
+ *     }
+ * }
+ * </pre>
+ *
+ * When you obtain an {@code InvokerBuilder} for the {@code hello()} method, you can
+ * immediately build a direct invoker. In a portable extension, this results in an invoker:
+ *
+ * <pre>
+ * InvokerBuilder&lt;Invoker&lt;MyService, String&gt;&gt; builder = ...;
+ * Invoker&lt;MyService, String&gt; invoker = builder.build();
+ * </pre>
+ *
+ * In a build compatible extension, this results in an opaque token that later
+ * materializes as an invoker:
+ *
+ * <pre>
+ * InvokerBuilder&lt;InvokerInfo&gt; builder = ...;
+ * InvokerInfo invoker = builder.build();
+ * </pre>
+ *
+ * To call the {@code hello()} method through this invoker, call
+ * {@code invoker.invoke(myService, new Object[] {"world"})}.
+ * The return value is {@code "Hello world!"}.
+ * <p>
+ * An implementation of the direct invoker above is equivalent to the following class:
+ *
+ * <pre>
+ * class TheInvoker implements Invoker&lt;MyService, String&gt; {
+ *     String invoke(MyService instance, Object[] arguments) {
+ *         return instance.hello((String) arguments[0]);
+ *     }
+ * }
+ * </pre>
+ *
+ * @param <T> type of the target instance
+ * @param <R> return type of the method
+ * @since 4.1
+ * @see #invoke(Object, Object[])
+ */
+public interface Invoker<T, R> {
+    /**
+     * Invokes the target method of this invoker on given {@code instance}, passing given
+     * {@code arguments}. If the target method is {@code static}, the {@code instance} is ignored;
+     * by convention, it should be {@code null}. If the target method returns normally, this
+     * method returns its return value, unless the target method is declared {@code void},
+     * in which case this method returns {@code null}. If the target method throws an exception,
+     * this method rethrows it directly.
+     * <p>
+     * If some parameter of the target method declares a primitive type, the corresponding element of
+     * the {@code arguments} array must be of the corresponding wrapper type. No type conversions are
+     * performed, so if the parameter is declared {@code int}, the argument must be an {@code Integer}
+     * and may not be {@code Short} or {@code Long}. If the argument is {@code null}, the default value
+     * of the primitive type is used. Note that this does not apply to arrays of primitive types;
+     * if a parameter is declared {@code int[]}, the argument must be {@code int[]} and may not be
+     * {@code Integer[]}.
+     * <p>
+     * If the target method is not {@code static} and {@code instance} is {@code null},
+     * a {@link NullPointerException} is thrown. If the target method is not {@code static} and
+     * the {@code instance} is not assignable to the class of the bean to which the method belongs,
+     * a {@link ClassCastException} is thrown.
+     * <p>
+     * If the target method declares no parameter, {@code arguments} are ignored. If the target method
+     * declares any parameter and {@code arguments} is {@code null}, {@link NullPointerException} is
+     * thrown. If the {@code arguments} array has fewer elements than the number of parameters of
+     * the target method, {@link ArrayIndexOutOfBoundsException} is thrown. If the {@code arguments}
+     * array has more elements than the number of parameters of the target method, the excess elements
+     * are ignored. If some of the {@code arguments} is not assignable to the declared type of
+     * the corresponding parameter of the target method, {@link ClassCastException} is thrown.
+     *
+     * TODO the previous 2 paragraphs refer to "assignability", which needs to be defined somewhere!
+     *
+     * @param instance the instance on which the target method is to be invoked, may only be {@code null}
+     *                 if the method is {@code static}
+     * @param arguments arguments to be supplied to the target method, may only be {@code null}
+     *                  if the method declares no parameter
+     * @return return value of the target method, or {@code null} if the method is declared {@code void}
+     */
+    R invoke(T instance, Object[] arguments); // TODO throws Exception ?
+}

--- a/api/src/main/java/jakarta/enterprise/invoke/Invoker.java
+++ b/api/src/main/java/jakarta/enterprise/invoke/Invoker.java
@@ -118,6 +118,10 @@ public interface Invoker<T, R> {
      *
      * TODO the previous 2 paragraphs refer to "assignability", which needs to be defined somewhere!
      *
+     * TODO when the `InvokerBuilder` applies transformations, some of the requirements above
+     *  are no longer strictly necessary, should reflect that in this text somehow (it is already
+     *  mentioned in `InvokerBuilder`, but that likely isn't enough)
+     *
      * @param instance the instance on which the target method is to be invoked, may only be {@code null}
      *                 if the method is {@code static}
      * @param arguments arguments to be supplied to the target method, may only be {@code null}

--- a/api/src/main/java/jakarta/enterprise/invoke/InvokerBuilder.java
+++ b/api/src/main/java/jakarta/enterprise/invoke/InvokerBuilder.java
@@ -11,16 +11,357 @@
 package jakarta.enterprise.invoke;
 
 /**
- * Builder of {@link Invoker}s.
+ * Builder of {@link Invoker}s that allows configuring input lookups, input and output
+ * transformations, and invoker wrapping. The method for which the invoker is built is
+ * called the <em>target method</em>. If a lookup is configured, the corresponding input
+ * of the invoker is ignored and an instance is looked up from the CDI container before
+ * the target method is invoked. If a transformation is configured, the corresponding input
+ * or output of the invoker is modified in certain way before or after the target method
+ * is invoked. If a wrapper is configured, the invoker is passed to custom code for getting
+ * invoked. As a result, the built {@code Invoker} instance may have more complex behavior
+ * than just directly calling the target method.
+ * <p>
+ * Transformations and wrapping are expressed by ordinary methods that must have
+ * a pre-defined signature, as described below. Such methods are called
+ * <em>transformers</em> and <em>wrappers</em>.
+ * <p>
+ * Invokers may only be built during deployment. It is not possible to build new invokers
+ * at application runtime.
+ *
+ * <h2>Example</h2>
+ *
+ * Before describing in detail how lookups, transformers and wrappers work, let's take
+ * a look at an example. Say we have the following bean with a method:
+ *
+ * <pre>
+ * class MyService {
+ *     String hello(String name) {
+ *         return "Hello " + name + "!";
+ *     }
+ * }
+ * </pre>
+ *
+ * And we want to build an invoker that looks up {@code MyService} from the CDI container,
+ * always passes the argument to {@code hello()} as all upper-case, and repeats the return
+ * value twice. To transform the argument, we can use the zero-parameter method
+ * {@code String.toUpperCase()}, and to transform the return value, we write a transformer
+ * as a simple {@code static} method:
+ *
+ * <pre>
+ * class Transformations {
+ *     static String repeatTwice(String str) {
+ *         return str + " " + str;
+ *     }
+ * }
+ * </pre>
+ *
+ * Then, assuming we have obtained the {@code InvokerBuilder} for {@code MyService.hello()},
+ * we can set up the lookup and transformations and build an invoker like so:
+ *
+ * <pre>
+ * builder.setInstanceLookup()
+ *        .setArgumentTransformer(0, String.class, "toUpperCase")
+ *        .setReturnValueTransformer(Transformations.class, "repeatTwice")
+ *        .build();
+ * </pre>
+ *
+ * The resulting invoker will be equivalent to the following class:
+ * <pre>
+ * class TheInvoker implements Invoker&lt;MyService, String&gt; {
+ *     String invoke(MyService ignored, Object[] arguments) {
+ *         MyService instance = CDI.current().select(MyService.class).get();
+ *         String argument = (String) arguments[0];
+ *         String transformedArgument = argument.toUpperCase();
+ *         String result = instance.hello(transformedArgument);
+ *         String transformedResult = Transformations.repeatTwice(result);
+ *         return transformedResult;
+ *     }
+ * }
+ * </pre>
+ *
+ * The caller of this invoker may pass {@code null} as the target instance, because
+ * the invoker will lookup the target instance on its own. Therefore, calling
+ * {@code invoker.invoke(null, new Object[] {"world"})} will return
+ * {@code "Hello WORLD! Hello WORLD!"}.
+ *
+ * <h2>General requirements</h2>
+ *
+ * To refer to a transformer or a wrapper, all methods in this builder accept:
+ * 1. the {@code Class} that that declares the method, and 2. the {@code String} name
+ * of the method.
+ * <p>
+ * Transformers may be {@code static}, in which case they must be declared directly
+ * on the given class, or they may be instance methods, in which case they may be declared
+ * on the given class or inherited from any of its supertypes.
+ * <p>
+ * It is possible to register only one transformer of each kind, or for each argument
+ * position in case of argument transformers. Attempting to register a second transformer
+ * of the same kind, or for the same argument position, leads to an exception.
+ * <p>
+ * Wrappers must be {@code static} and must be declared directly on the given class.
+ * It is possible to register only one wrapper. Attempting to register a second wrapper
+ * leads to an exception.
+ * <p>
+ * It is a deployment problem if no method with given name and valid signature is found,
+ * or if multiple methods with given name and different valid signatures are found. It is
+ * a deployment problem if a registered transformer or wrapper is not {@code public}.
+ * <p>
+ * Transformers and wrappers may declare the {@code throws} clause. The declared exception
+ * types are ignored when searching for the method.
+ * <p>
+ * For the purpose of the specification of transformers and wrappers below, the term
+ * <em>any-type</em> is recursively defined as: the {@code java.lang.Object} class type,
+ * or a type variable that has no bound, or a type variable whose first bound is
+ * <em>any-type</em>.
+ *
+ * <h2>Input lookups</h2>
+ *
+ * For the target instance and for each argument, it is possible to specify that the value
+ * passed to {@code Invoker.invoke()} should be ignored and a value should be looked up
+ * from the CDI container instead.
+ * <p>
+ * For the target instance, a CDI lookup is performed with the required type equal to the bean
+ * class of the bean to which the target method belongs, and required qualifiers equal to the set
+ * of all qualifier annotations present on the bean class of the bean to which the target method
+ * belongs. When the target method is {@code static}, the target instance lookup is skipped.
+ * <p>
+ * For an argument, a CDI lookup is performed with the required type equal to the type of
+ * the corresponding parameter of the target method, and required qualifiers equal to the set
+ * of all qualifier annotations present on the corresponding parameter of the target method.
+ * <p>
+ * Implementations are required to resolve all lookups during deployment. It is a deployment
+ * problem if the lookup ends up unresolved or ambiguous.
+ * <p>
+ * If the looked up bean is {@code @Dependent}, it is guaranteed that the instance will be
+ * destroyed after the target method is invoked but before the the invoker returns. The order
+ * in which the looked up {@code @Dependent} beans are destroyed is not specified.
+ * <p>
+ * The order in which input lookups are performed in not specified and must not be relied upon.
+ *
+ * <h2>Input transformations</h2>
+ *
+ * The target method has 2 kinds of inputs: the target instance (unless the target method is
+ * {@code static}, in which case the target instance is ignored and should be {@code null}
+ * by convention) and arguments. These inputs correspond to the parameters of
+ * {@link Invoker#invoke(Object, Object[]) Invoker.invoke()}.
+ * <p>
+ * Each input can be transformed by a transformer that has one of the following signatures,
+ * where {@code X} and {@code Y} are types:
+ *
+ * <ul>
+ * <li>{@code static X transform(Y value)}</li>
+ * <li>{@code static X transform(Y value, Consumer<Runnable> cleanup)}</li>
+ * <li>{@code X transform()} &ndash; in this case, {@code Y} is the type of the class that
+ * declares the transformer</li>
+ * </ul>
+ *
+ * An input transformer must produce a type that can be consumed by the target method.
+ * Specifically: when {@code X} is <em>any-type</em>, it is not type checked during deployment.
+ * Otherwise, it is a deployment problem if {@code X} is not assignable to the corresponding type
+ * in the declaration of the target method (that is the bean class in case of target instance
+ * transformers, or the corresponding parameter type in case of argument transformers). {@code Y}
+ * is not type checked during deployment, so that input transformers may consume arbitrary types.
+ * TODO this paragraph refers to "assignability", which needs to be defined somewhere!
+ * <p>
+ * When a transformer is registered for given input, it is called before the target method is
+ * invoked, and the outcome of the transformer is used in the invocation instead of the original
+ * value passed to the invoker by its caller.
+ * <p>
+ * If the transformer declares the {@code Consumer<Runnable>} parameter, and the execution
+ * of the transformer calls {@code Consumer.accept()} with some {@code Runnable}, it is
+ * guaranteed that the {@code Runnable} will be called after the target method is invoked but
+ * before the invoker returns. These {@code Runnable}s are called <em>cleanup tasks</em>.
+ * The order of cleanup task execution is not specified. Passing a {@code null} cleanup task
+ * to the {@code Consumer} is permitted, but has no effect.
+ * <p>
+ * If an input transformation is configured for an input for which a lookup is also configured,
+ * the lookup is performed first and the transformation is applied to the looked up value.
+ * If the looked up bean for some input is {@code @Dependent}, it is guaranteed that all
+ * cleanup tasks registered by a transformer for that input are called before that looked up
+ * {@code @Dependent} bean is destroyed.
+ * <p>
+ * The order in which input transformations are performed in not specified and must not
+ * be relied upon.
+ *
+ * <h2>Output transformations</h2>
+ *
+ * The target method has 2 kinds of outputs: the return value and the thrown exception. These
+ * outputs correspond to the return value of {@link Invoker#invoke(Object, Object[]) Invoker.invoke()}
+ * or its thrown exception, respectively.
+ * <p>
+ * Each output can be transformed by a transformer that has one of the following signatures,
+ * where {@code X} and {@code Y} are types:
+ *
+ * <ul>
+ * <li>{@code static X transform(Y value)}</li>
+ * <li>{@code X transform()} &ndash; in this case, {@code Y} is the type of the class that
+ * declares the transformer</li>
+ * </ul>
+ *
+ * An output transformer must consume a type that can be produced by the target method.
+ * Specifically: when {@code Y} is <em>any-type</em>, it is not type checked during deployment.
+ * Otherwise, it is a deployment problem if {@code Y} is not assignable from the return type of
+ * the target method in case of return value transformers, or from {@code java.lang.Throwable}
+ * in case of exception transformers. {@code X} is not type checked during deployment, so that
+ * output transformers may produce arbitrary types.
+ * TODO this paragraph refers to "assignability", which needs to be defined somewhere!
+ * <p>
+ * When a transformer is registered for given output, it is called after the target method
+ * is invoked, and the outcome of the transformer is passed back to the caller of the invoker
+ * instead of the original output produced by the target method.
+ * <p>
+ * If the target method returns normally, any registered exception transformer is ignored; only
+ * the return value transformer is called. The return value transformer may throw, in which case
+ * the invoker will rethrow the exception. If the invoker is supposed to return normally,
+ * the return value transformer must return normally.
+ * <p>
+ * Similarly, if the target method throws, any registered return value transformer is ignored;
+ * only the exception transformer is called. The exception transformer may return normally,
+ * in which case the invoker will return the return value of the exception transformer. If
+ * the invoker is supposed to throw an exception, the exception transformer must throw.
+ * TODO this requires that implementations catch java.lang.Throwable, which is perhaps a bit too much?
+ *  maybe stick with java.lang.Exception?
+ *
+ * <h2>Invoker wrapping</h2>
+ *
+ * An invoker, possibly utilizing input lookups and input/output transformations, may be wrapped
+ * by a custom piece of code for maximum flexibility. A wrapper must have the following signature,
+ * where {@code X}, {@code Y} and {@code Z} are types:
+ *
+ * <ul>
+ * <li>{@code static Z wrap(X instance, Object[] arguments, Invoker<X, Y> invoker)}</li>
+ * </ul>
+ *
+ * A wrapper must operate on a matching instance type. Specifically: when {@code X} is
+ * <em>any-type</em>, it is not type checked during deployment. Otherwise, it is a deployment
+ * problem if {@code X} is not assignable from the class type of the bean class to which
+ * the target method belongs. {@code Y} and {@code Z} are not type checked during deployment.
+ * <p>
+ * When a wrapper is registered, 2 invokers for the same method are created. The <em>inner</em>
+ * invoker applies all lookups and transformations, as described in previous sections, and
+ * invokes the target method. The <em>outer</em> invoker calls the wrapper with the passed
+ * instance and arguments and an instance of the inner invoker. The outer invoker is returned
+ * by this invoker builder.
+ * <p>
+ * In other words, the outer invoker is equivalent to the following class:
+ *
+ * <pre>
+ * class InvokerWrapper implements Invoker&lt;X, Z&gt; {
+ *     Z invoke(X instance, Object[] arguments) {
+ *         // obtain the invoker as if no wrapper existed
+ *         Invoker&lt;X, Y&gt; invoker = obtainInvoker();
+ *         return SomeClass.wrap(instance, arguments, invoker);
+ *     }
+ * }
+ * </pre>
+ *
+ * If the wrapper returns normally, the outer invoker returns its return value, unless the wrapper
+ * is declared {@code void}, in which case the outer invoker returns {@code null}. If the wrapper
+ * throws an exception, the outer invoker rethrows it directly.
+ * <p>
+ * The wrapper is supposed to call the invoker it is passed, but does not necessarily have to.
+ * The wrapper may call the invoker multiple times. The wrapper must not use the invoker
+ * in any other way; specifically, it is forbidden to store the invoker instance anywhere
+ * or pass it to other methods that do not follow these rules. Doing so leads to non-portable
+ * behavior.
+ *
+ * <h2>Type checking</h2>
+ *
+ * An invoker created by this builder has relaxed type checking rules, when compared to
+ * the description in {@link Invoker#invoke(Object, Object[]) Invoker.invoke()}, depending
+ * on configured lookups, transformers and wrapper. Some types are checked during
+ * deployment, as described in previous sections. Other types are checked during invocation,
+ * at the very least due to the type checks performed implicitly by the JVM. The lookups,
+ * transformers and the wrapper must arrange the inputs and outputs so that when the method
+ * is eventually invoked, the rules described in
+ * {@link Invoker#invoke(Object, Object[]) Invoker.invoke()} all hold.
+ * <p>
+ * TODO specify what happens when a transformer/wrapper declares a parameter of a primitive type
+ *  but the actual value passed to the invoker is `null` (the transformer should get a zero value?)
+ * TODO specify what happens when a transformer/wrapper declares a parameter of some type
+ *  but the actual value passed to the invoker is not assignable to it (CCE?)
  *
  * @param <T> type of outcome of this builder; always represents an {@code Invoker},
  *            but does not necessarily have to be an {@code Invoker} instance directly
  * @since 4.1
  */
+// TODO more kinds of transformations could be defined, expecially for argument handling
+// TODO it would be possible to specify a sequence of transformations for each input/output, instead of just one
 public interface InvokerBuilder<T> {
     /**
+     * Enables lookup of the target instance.
+     *
+     * @return this builder
+     */
+    InvokerBuilder<T> setInstanceLookup();
+
+    /**
+     * Enables lookup of the argument on given {@code position}.
+     *
+     * @param position zero-based argument position for which lookup is enabled
+     * @return this builder
+     * @throws IllegalArgumentException if {@code position} is greather than or equal to
+     * the number of parameters declared by the target method
+     */
+    InvokerBuilder<T> setArgumentLookup(int position);
+
+    /**
+     * Configures an input transformer for the target instance.
+     *
+     * @param clazz class that declares the transformer
+     * @param methodName transformer method name
+     * @return this builder
+     * @throws IllegalStateException if this method is called more than once
+     */
+    InvokerBuilder<T> setInstanceTransformer(Class<?> clazz, String methodName);
+
+    /**
+     * Configures an input transformer for the argument on given {@code position}.
+     *
+     * @param position zero-based argument position for which the input transformer is configured
+     * @param clazz class that declares the transformer
+     * @param methodName transformer method name
+     * @return this builder
+     * @throws IllegalArgumentException if {@code position} is greather than or equal to
+     * the number of parameters declared by the target method
+     * @throws IllegalStateException if this method is called more than once with the same {@code position}
+     */
+    InvokerBuilder<T> setArgumentTransformer(int position, Class<?> clazz, String methodName);
+
+    /**
+     * Configures an output transformer for the return value.
+     *
+     * @param clazz class that declares the transformer
+     * @param methodName transformer method name
+     * @return this builder
+     * @throws IllegalStateException if this method is called more than once
+     */
+    InvokerBuilder<T> setReturnValueTransformer(Class<?> clazz, String methodName);
+
+    /**
+     * Configures an output transformer for the thrown exception.
+     *
+     * @param clazz class that declares the transformer
+     * @param methodName transformer method name
+     * @return this builder
+     * @throws IllegalStateException if this method is called more than once
+     */
+    InvokerBuilder<T> setExceptionTransformer(Class<?> clazz, String methodName);
+
+    /**
+     * Configures an invoker wrapper.
+     *
+     * @param clazz class that declares the invoker wrapper
+     * @param methodName invoker wrapper method name
+     * @return this builder
+     * @throws IllegalStateException if this method is called more than once
+     */
+    InvokerBuilder<T> setInvocationWrapper(Class<?> clazz, String methodName);
+
+    /**
      * Returns the built {@link Invoker} or some represention of it. Implementations are allowed
-     * but not required to reuse already built invokers for the same target method.
+     * but not required to reuse already built invokers for the same target method with the same
+     * configuration.
      *
      * @return the built invoker
      */

--- a/api/src/main/java/jakarta/enterprise/invoke/InvokerBuilder.java
+++ b/api/src/main/java/jakarta/enterprise/invoke/InvokerBuilder.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2022 Red Hat and others
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package jakarta.enterprise.invoke;
+
+/**
+ * Builder of {@link Invoker}s.
+ *
+ * @param <T> type of outcome of this builder; always represents an {@code Invoker},
+ *            but does not necessarily have to be an {@code Invoker} instance directly
+ * @since 4.1
+ */
+public interface InvokerBuilder<T> {
+    /**
+     * Returns the built {@link Invoker} or some represention of it. Implementations are allowed
+     * but not required to reuse already built invokers for the same target method.
+     *
+     * @return the built invoker
+     */
+    T build();
+}

--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -10,6 +10,7 @@ module jakarta.cdi {
     exports jakarta.enterprise.inject.se;
     exports jakarta.enterprise.inject.spi;
     exports jakarta.enterprise.inject.spi.configurator;
+    exports jakarta.enterprise.invoke;
     exports jakarta.enterprise.util;
 
     requires transitive jakarta.annotation;


### PR DESCRIPTION
This PR has 2 commits with detailed commit messages. I'm copying the commit messages here for easier reference.

This PR doesn't include changes to the specification text, but the API javadocs are intentionally a specification-level material. There are several TODOs and everything is up for debate anyway, but I still wanted to provide something that is pretty well defined.

## Initial proposal for method invokers: introduce core concepts

_`Invoker`_ is an indirect way of invoking a bean method. It is a simple
functional interface:

```java
interface Invoker<T, R> {
    R invoke(T instance, Object[] arguments);
}
```

Invokers are built using an _`InvokerBuilder`_. They must be thread-safe,
so frameworks can build an invoker for each relevant method once and then
reuse it to invoke that method whenever necessary.

An invoker may be built for a method that:

1. is not `private`;
2. is not a constructor;
3. is declared on a bean class of a managed bean (class-based bean),
   with the exception of interceptors and decorators, or inherited
   from its supertypes.

If an invocation of a method is intercepted, an equivalent invocation
through an invoker is also intercepted.

Portable extensions may obtain an `InvokerBuilder` in an observer
of the `ProcessManagedBean` type. The `InvokerBuilder` in this case
produces `Invoker` objects directly.

Build compatible extensions may obtain an `InvokerBuilder` during
`@Registration` from the `BeanInfo` object. The `InvokerBuilder` in
this case produces `InvokerInfo` objects. `InvokerInfo` is an opaque
token that can only be used to materialize an `Invoker` in synthetic
components.

## Initial proposal for method invokers: invoker builder features

This commit introduces actual interesting features to the `InvokerBuilder`:

- automatic lookup of the target instance and arguments
- transformation of the target instance and arguments before invocation
- transformation of the return value and thrown exception after invocation
- wrapping the invoker into a custom piece of code for maximum flexibility
