### PR TITLE
Use a vendor neutral link to the license text

### DIFF
--- a/lang-model/pom.xml
+++ b/lang-model/pom.xml
@@ -16,7 +16,7 @@
 	<licenses>
 		<license>
 			<name>Apache License 2.0</name>
-			<url>https://repository.jboss.org/licenses/apache-2.0.txt</url>
+			<url>https://apache.org/licenses/LICENSE-2.0.txt</url>
 			<distribution>repo</distribution>
 		</license>
 	</licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 	<licenses>
 		<license>
 			<name>Apache License 2.0</name>
-			<url>https://repository.jboss.org/licenses/apache-2.0.txt</url>
+			<url>https://apache.org/licenses/LICENSE-2.0.txt</url>
 			<distribution>repo</distribution>
 		</license>
 	</licenses>


### PR DESCRIPTION
Pragmatically speaking, the vendor neutral link will increase the odds that license scanners will correctly identify the license.

Philosophically speaking, the vendor neutral link reinforces the vendor neutral nature of the project.