### PR TITLE
Clarify how vetoing a specialized bean works

### DIFF
--- a/spec/src/main/asciidoc/core/spi_full.asciidoc
+++ b/spec/src/main/asciidoc/core/spi_full.asciidoc
@@ -1300,7 +1300,7 @@ public interface ProcessBeanAttributes<T> {
 * `configureBeanAttributes()` returns a `BeanAttributesConfigurator` (as defined in <<bean_attributes_configurator>>) initialized with the `BeanAttributes` processed by the event to easily configure the  `BeanAttributes` which will be used to replace the original one at the end of observer invocation.
 The method always returns the same `BeanAttributesConfigurator`.
 * `addDefinitionError()` registers a definition error with the container, causing the container to abort deployment after bean discovery is complete.
-* `veto()` forces the container to ignore the bean.
+* `veto()` forces the container to ignore the bean. If invoked on a bean `A` that directly specializes bean `B` (as defined in <<specialize_managed_bean>>), this causes re-enablement of the specialized bean `B` and the container must raise a `ProcessBeanAttribute` event for newly re-enabled bean `B`.
 * `ignoreFinalMethods()` Instructs the container to ignore all non-static, final methods with public, protected or default visibility declared on any bean type of the specific bean during validation of injection points that require proxyable bean type.
 These method should never be invoked upon bean instances.
 Otherwise, unpredictable behavior results.


### PR DESCRIPTION
A suggestion for clarification related to recent discussion in https://github.com/jakartaee/cdi-tck/issues/440

It tried to clarify two unclear things:
* It states that bean re-enablement happens if you `veto()` specializing bean
  * I found no other place in spec that would say this happens but I don't think there is a disagreement on that since keeping the original bean disabled provides no benefit.
* It explicitly defines what happens WRT `ProcessBeanAttributes` of the newly re-enabled bean
  * This is in line with [bean discovery](https://jakarta.ee/specifications/cdi/4.0/jakarta-cdi-spec-4.0.html#bean_discovery_steps_full) chapter requiring that PBA is fired for enabled beans only

This change follows what the TCK test already asserts.

Thoughts are welcome.

CC @Ladicek @jeanouii