### PR TITLE
Fix missing wording about priority on stereotypes

### DIFF
--- a/spec/src/main/asciidoc/core/injectionandresolution.asciidoc
+++ b/spec/src/main/asciidoc/core/injectionandresolution.asciidoc
@@ -45,7 +45,8 @@ An alternative is not available for injection, lookup or name resolution to clas
 An alternative may be given a priority for the application:
 
 * by placing the `@Priority` annotation on the bean class of a managed bean, or
-* by placing the `@Priority` annotation on the bean class that declares the producer method, field or resource.
+* by placing the `@Priority` annotation on the bean class that declares the producer method, field or resource, or
+* by placing the `@Priority` annotation on a stereotype that is applied to the bean class, producer method or producer field.
 
 [[enablement]]
 


### PR DESCRIPTION
Fixes #649

This is a follow-up on #495 (#524, #527, #557). It doesn't add any new specification, merely adds information to one place that is already present on other places, for better internal consistency.