### PR TITLE
Fix two small wording mistakes

### DIFF
--- a/spec/src/main/asciidoc/core/injectionandresolution.asciidoc
+++ b/spec/src/main/asciidoc/core/injectionandresolution.asciidoc
@@ -68,7 +68,7 @@ A bean is _available for injection_ in a certain module if:
 
 * the bean is not an interceptor
 * the bean is enabled,
-* the bean is either not an alternative, or the module is a bean archive and the bean is a selected alternative for the application,  and
+* the bean is either not an alternative, or the bean is a selected alternative for the application, and
 * the bean class is required to be accessible to classes in the module, according to the class accessibility requirements of the module architecture.
 
 [[typesafe_resolution]]

--- a/spec/src/main/asciidoc/core/injectionandresolution.asciidoc
+++ b/spec/src/main/asciidoc/core/injectionandresolution.asciidoc
@@ -107,7 +107,7 @@ An _unsatisfied dependency_ exists at an injection point when no bean is eligibl
 An _ambiguous dependency_ exists at an injection point when multiple beans are eligible for injection to the injection point.
 
 When an ambiguous dependency exists, the container attempts to resolve the ambiguity.
-The container eliminates all eligible beans that are not alternatives selected for the application, except for producer methods and fields of beans that are alternatives.
+The container eliminates all eligible beans that are not alternatives, except for producer methods and fields of beans that are alternatives.
 If:
 
 * there is exactly one bean remaining, the container will select this bean, and the ambiguous dependency is called resolvable.


### PR DESCRIPTION
## Revert incorrect change in ambiguity resolution

We previously [1] changed the ambiguity resolution wording from

> The container eliminates all eligible beans that are not alternatives,
> except for producer methods and fields of beans that are alternatives.

to

> The container eliminates all eligible beans that are not alternatives
> selected for the application, except for producer methods and fields
> of beans that are alternatives.

At that time, we did _not_ add a rule to the CDI Full section that would
cover alternatives selected for the bean archive.

Note that for a bean to be _eligible_, it must be _available for injection_,
and an alternative is available for injection only if it is selected (for
application in CDI Lite; for application or for bean archive in CDI Full).
Alternative beans that are not selected are hence not even considered during
ambiguity resolution, so the ambiguity resolution description does not need
to mention them at all. This is why the previous description is correct.

Now, only eliminating beans that are not alternatives selected for application,
as the new text says, would mean that in CDI Full, beans that are alternatives
selected for bean archive would also be eliminated. That would be wrong.

Therefore, this change is incorrect. Of course, no implementation actually
made that change in behavior, and the TCK wasn't adjusted either.

There are 2 ways to fix this: revert to previous wording, or add extra wording
to the CDI Full section:

> The container eliminates all eligible beans that are not alternatives
> selected for the bean archive or selected for the application, except
> for producer methods and fields of beans that are alternatives.

This would be similar how ambiguous name resolution is specified.

This commit simply reverts to the previous wording, because that's easier,
even though it leads to slight inconsistency between ambiguous dependency
resolution and ambiguous name resolution. That inconsistency exists since
CDI 1.1, so is not an issue.

[1] https://github.com/jakartaee/cdi/commit/1840939753dee2af56cb9a8698ce4dc00c81e977

## Fix the definition of availability for injection

We previously [2] changed the definition of _availability for injection_
from

> the bean is either not an alternative, or the module is a bean archive
> and the bean is a selected alternative of the bean archive, or the bean
> is a selected alternative of the application

to

> the bean is either not an alternative, or the module is a bean archive
> and the bean is a selected alternative for the application

in the CDI Lite section of the specification. The CDI Full section has
the original wording verbatim, so it does not have an issue.

The new wording is clearly wrong though, because the it mixes the 2nd and
3rd clause of the original sentence. What we should have done is to only
remove the 2nd clause:

> the bean is either not an alternative, or the bean is a selected
> alternative of the application

This commit does that.

[2] https://github.com/jakartaee/cdi/commit/693139b302b497df00461d40d4eb2c674bb052fa