### PR TITLE
Move the specification of BeanManager.getInjectableReference() to CDI Full

### DIFF
--- a/api/src/main/java/jakarta/enterprise/inject/spi/BeanManager.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/BeanManager.java
@@ -93,6 +93,22 @@ import jakarta.enterprise.inject.Stereotype;
 public interface BeanManager extends BeanContainer {
 
     /**
+     * <p>
+     * Obtains an injectable reference for a certain {@linkplain InjectionPoint injection point}.
+     * </p>
+     *
+     * @param ij  the target injection point
+     * @param ctx a {@link CreationalContext} that may be used to destroy any object with scope
+     *            {@link Dependent} that is created
+     * @return the injectable reference
+     * @throws UnsatisfiedResolutionException if typesafe resolution results in an unsatisfied dependency
+     * @throws AmbiguousResolutionException   typesafe resolution results in an unresolvable ambiguous dependency
+     * @throws IllegalStateException          if called during application initialization, before the {@link AfterDeploymentValidation}
+     *                                        event is fired.
+     */
+    Object getInjectableReference(InjectionPoint ij, CreationalContext<?> ctx);
+
+    /**
      * Returns the {@link PassivationCapable} bean with the given identifier.
      *
      * Note that when called during invocation of an {@link AfterBeanDiscovery} event observer, 
@@ -120,24 +136,6 @@ public interface BeanManager extends BeanContainer {
      *         event is fired.
      */
     public void validate(InjectionPoint injectionPoint);
-
-    /**
-     * Return an ordered set of {@linkplain ObserverMethod observer methods} for an event.
-     *
-     * Note that when called during invocation of an {@link AfterBeanDiscovery} event observer,
-     * this method will only return observers discovered by the container before the {@link AfterBeanDiscovery} event is fired.
-     * 
-     * @param <T> the type of the event
-     * @param event the event object
-     * @param qualifiers the event qualifiers
-     * @return the resulting set of {@linkplain ObserverMethod observer methods}
-     * @throws IllegalArgumentException if the runtime type of the event object contains a type variable
-     * @throws IllegalArgumentException if two instances of the same non repeating qualifier type are given
-     * @throws IllegalArgumentException if an instance of an annotation that is not a qualifier type is given
-     * @throws IllegalStateException if called during application initialization, before the {@link AfterBeanDiscovery}
-     *         event is fired.
-     */
-    public <T> Set<ObserverMethod<? super T>> resolveObserverMethods(T event, Annotation... qualifiers);
 
     /**
      * Return an ordered list of {@linkplain Decorator decorators} for a set of bean types and a set of qualifiers and which are
@@ -423,19 +421,4 @@ public interface BeanManager extends BeanContainer {
      */
     <T> InterceptionFactory<T> createInterceptionFactory(CreationalContext<T> ctx, Class<T> clazz);
 
-    /**
-     * <p>
-     * Obtains an injectable reference for a certain {@linkplain InjectionPoint injection point}.
-     * </p>
-     *
-     * @param ij  the target injection point
-     * @param ctx a {@link CreationalContext} that may be used to destroy any object with scope
-     *            {@link Dependent} that is created
-     * @return the injectable reference
-     * @throws UnsatisfiedResolutionException if typesafe resolution results in an unsatisfied dependency
-     * @throws AmbiguousResolutionException   typesafe resolution results in an unresolvable ambiguous dependency
-     * @throws IllegalStateException          if called during application initialization, before the {@link AfterDeploymentValidation}
-     *                                        event is fired.
-     */
-    Object getInjectableReference(InjectionPoint ij, CreationalContext<?> ctx);
 }

--- a/spec/src/main/asciidoc/core/beanmanager_lite.asciidoc
+++ b/spec/src/main/asciidoc/core/beanmanager_lite.asciidoc
@@ -90,24 +90,6 @@ The third parameter is an instance of `CreationalContext` that may be used to de
 
 If the given type is not a bean type of the given bean, an `IllegalArgumentException` is thrown.
 
-[[bm_obtain_injectable_reference]]
-
-==== Obtaining an injectable reference
-
-The method `BeanContainer.getInjectableReference()` returns an injectable reference for a given injection point, as defined in <<injectable_reference>>.
-
-[source, java]
-----
-public Object getInjectableReference(InjectionPoint ij, CreationalContext<?> ctx);
-----
-
-The first parameter represents the target injection point.
-The second parameter is an instance of `CreationalContext` that may be used to destroy any object with scope `@Dependent` that is created.
-
-If typesafe resolution results in an unsatisfied dependency, the container must throw an `UnsatisfiedResolutionException`. If typesafe resolution results in an unresolvable ambiguous dependency, the container must throw an `AmbiguousResolutionException`.
-
-Implementations of `Bean` usually maintain a reference to an instance of `BeanContainer`. When the `Bean` implementation performs dependency injection, it must obtain the contextual instances to inject by calling `BeanContainer.getInjectableReference()`, passing an instance of `InjectionPoint` that represents the injection point and the instance of `CreationalContext` that was passed to `Bean.create()`.
-
 [[bm_obtain_creationalcontext]]
 
 ==== Obtaining a `CreationalContext`

--- a/spec/src/main/asciidoc/core/spi_full.asciidoc
+++ b/spec/src/main/asciidoc/core/spi_full.asciidoc
@@ -256,13 +256,26 @@ A portable extension or other object may obtain a reference to the current conta
 `CDI.getBeanManager()` and `CDI.getBeanContainer()` may be called at any time after the container fires the `BeforeBeanDiscovery` container lifecycle event until the container fires the `BeforeShutdown` container lifecycle event.
 If methods on `CDI` are called at any other time, non-portable behavior results.
 
-[[bm_obtain_injectable_reference_full]]
+[[bm_obtain_injectable_reference]]
 
-==== Obtaining an injectable reference in {cdi_full}
+==== Obtaining an injectable reference
 
-In addition to rules defined in <<bm_obtain_injectable_reference>>, the following rules apply.
+The method `BeanManager.getInjectableReference()` returns an injectable reference for a given injection point, as defined in <<injectable_reference>>.
+
+[source, java]
+----
+public Object getInjectableReference(InjectionPoint ij, CreationalContext<?> ctx);
+----
+
+The first parameter represents the target injection point.
+The second parameter is an instance of `CreationalContext` that may be used to destroy any object with scope `@Dependent` that is created.
 
 If the `InjectionPoint` represents a decorator delegate injection point, `getInjectableReference()` returns a delegate, as defined in <<delegate_attribute>>.
+
+If typesafe resolution results in an unsatisfied dependency, the container must throw an `UnsatisfiedResolutionException`. If typesafe resolution results in an unresolvable ambiguous dependency, the container must throw an `AmbiguousResolutionException`.
+
+Implementations of `Bean` usually maintain a reference to an instance of `BeanManager`. When the `Bean` implementation performs dependency injection, it must obtain the contextual instances to inject by calling `BeanManager.getInjectableReference()`, passing an instance of `InjectionPoint` that represents the injection point and the instance of `CreationalContext` that was passed to `Bean.create()`.
+
 
 [[bm_obtain_unmanaged_instance]]
 


### PR DESCRIPTION
We previously [1] moved the `getInjectableReference()` from the `BeanContainer` interface to the `BeanManager` [2], but did not update the specification text accordingly. Thus, the method is specified in the CDI Lite part of the spec, but it in fact belongs to CDI Full. This commit moves the spec text around to fix that.

Additionally, this commit removes the declaration of `resolveObserverMethods()` from `BeanManager`, because that just overrides the same declaration that is present on `BeanContainer`.

Finally, this commit moves the declaration of `getInjectableReference()` from the end of the `BeanManager` source code to the beginning, for symmetry with the `BeanContainer` declaration and to restore the previous layout.

[1] https://github.com/jakartaee/cdi/commit/520bad1989101bf4523e13e8e0c8f2d23cdc34b6
[2] https://github.com/jakartaee/cdi/issues/568