### PR TITLE
Fix Javadoc for createInstance validity

### DIFF
--- a/api/src/main/java/jakarta/enterprise/inject/spi/BeanContainer.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/BeanContainer.java
@@ -241,10 +241,6 @@ public interface BeanContainer {
      * or, in the Jakarta EE environment, the Jakarta EE component from whose JNDI environment namespace the
      * <code>BeanContainer</code> was obtained, according to the rules of typesafe resolution.
      * <p>
-     * Note that when called during invocation of an {@link AfterBeanDiscovery} event observer,
-     * the <code>Instance</code> returned by this method will only give access to instances of beans discovered by the container
-     * before the {@link AfterBeanDiscovery} event is fired.
-     * <p>
      * Instances of dependent scoped beans obtained with this <code>Instance</code> must be explicitly destroyed by calling {@link Instance#destroy(Object)}
      * <p>
      * If no qualifier is passed to {@link Instance#select} method, the <code>@Default</code> qualifier is assumed.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/BeanManager.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/BeanManager.java
@@ -71,12 +71,12 @@ import jakarta.enterprise.inject.Stereotype;
  *     <li>{@link #resolveInterceptors(InterceptionType, java.lang.annotation.Annotation...)},</li>
  *     <li>{@link #resolveObserverMethods(Object, java.lang.annotation.Annotation...)},</li>
  *     <li>{@link #validate(InjectionPoint)},</li>
- *     <li>{@link #createInstance()}</li>
  * </ul>
  * <p>
  * and the following operations must not be called before the {@link AfterDeploymentValidation} event is fired:
  * </p>
  * <ul>
+ *     <li>{@link #createInstance()}</li>
  *     <li>{@link #getReference(Bean, java.lang.reflect.Type, CreationalContext)},</li>
  *     <li>{@link #getInjectableReference(InjectionPoint, CreationalContext)},</li>
  * </ul>


### PR DESCRIPTION
The spec and TCK assert that `BeanContainer.createInstance()` must not be called before the `AfterDeploymentValidation` event is fired.

Correct some Javadoc which was inconsistent.

Fixes #688 