### PR TITLE
Fix guards against repeated external sets of SPI implementations

### DIFF
--- a/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/BuildServicesResolver.java
+++ b/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/BuildServicesResolver.java
@@ -82,7 +82,7 @@ public final class BuildServicesResolver {
         if (instance == null) {
             throw new IllegalArgumentException("BuildServices instance must not be null");
         }
-        if (configuredBuildServices != null) {
+        if (configuredBuildServices == null) {
             configuredBuildServices = instance;
         } else {
             throw new IllegalStateException("BuildServices cannot be set repeatedly. Existing BuildServices are " + configuredBuildServices);

--- a/api/src/main/java/jakarta/enterprise/inject/spi/CDI.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/CDI.java
@@ -123,7 +123,7 @@ public abstract class CDI<T> implements Instance<T> {
         if (provider == null) {
             throw new IllegalArgumentException("CDIProvider must not be null");
         }
-        if (configuredProvider != null) {
+        if (configuredProvider == null) {
             providerSetManually = true;
             configuredProvider = provider;
         } else {


### PR DESCRIPTION
We previously [1] added code to guard against repeated calls to these SPIs:

- `BuildServicesResolver.setBuildServices()`
- `CDI.setCDIProvider()`

The guards are unfortunately incorrect. This commit fixes them.

[1] https://github.com/jakartaee/cdi/commit/82ec5d71872212364a321cd3700d0ecadf9162d2