### PR TITLE
Specify behavior for sealed types

### DIFF
--- a/spec/src/main/asciidoc/core/definition.asciidoc
+++ b/spec/src/main/asciidoc/core/definition.asciidoc
@@ -81,7 +81,7 @@ The bean types of a bean are used by the rules of typesafe resolution defined in
 
 Almost any Java type may be a bean type of a bean:
 
-* A bean type may be an interface, a concrete class or an abstract class, and may be declared final or have final methods.
+* A bean type may be an interface, a concrete class or an abstract class, may be declared sealed or non-sealed or final, and may have final methods.
 * A bean type may be a parameterized type with actual type parameters and type variables.
 * A bean type may be an array type.
 Two array types are considered identical only if the element type is identical.

--- a/spec/src/main/asciidoc/core/implementation.asciidoc
+++ b/spec/src/main/asciidoc/core/implementation.asciidoc
@@ -662,6 +662,7 @@ Certain legal bean types cannot be proxied by the container:
 * classes which don't have a non-private constructor with no parameters,
 * classes which are declared final,
 * classes which have non-static, final methods with public, protected or default visibility,
+* sealed classes and sealed interfaces,
 * primitive types,
 * and array types.
 


### PR DESCRIPTION
Sealed types are valid bean types, but they are unproxyable.

This commit only makes explicit what already implicitly follows from
the existing CDI specification and updates in the Java / JVM specifications.
