### PR TITLE
Allow setting CDI SPI implementations repeatedly

### DIFF
--- a/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/BuildServicesResolver.java
+++ b/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/BuildServicesResolver.java
@@ -76,16 +76,11 @@ public final class BuildServicesResolver {
      *
      * @param instance a {@link BuildServices} instance that should be used, must not be {@code null}
      * @throws IllegalArgumentException if the provided argument is null
-     * @throws IllegalStateException if the {@link BuildServices} are already set
      */
     public static void setBuildServices(BuildServices instance) {
         if (instance == null) {
             throw new IllegalArgumentException("BuildServices instance must not be null");
         }
-        if (configuredBuildServices == null) {
-            configuredBuildServices = instance;
-        } else {
-            throw new IllegalStateException("BuildServices cannot be set repeatedly. Existing BuildServices are " + configuredBuildServices);
-        }
+        configuredBuildServices = instance;
     }
 }

--- a/api/src/main/java/jakarta/enterprise/inject/spi/CDI.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/CDI.java
@@ -116,19 +116,14 @@ public abstract class CDI<T> implements Instance<T> {
      * </p>
      *
      * @param provider the provider to use
-     * @throws IllegalStateException if the {@link CDIProvider} is already set
      * @throws IllegalArgumentException if the provided argument is null
      */
     public static void setCDIProvider(CDIProvider provider) {
         if (provider == null) {
             throw new IllegalArgumentException("CDIProvider must not be null");
         }
-        if (configuredProvider == null) {
-            providerSetManually = true;
-            configuredProvider = provider;
-        } else {
-            throw new IllegalStateException("CDIProvider cannot be set repeatedly. Existing provider is " + configuredProvider);
-        }
+        providerSetManually = true;
+        configuredProvider = provider;
     }
 
     private static void findAllProviders() {


### PR DESCRIPTION
The `CDI.setCDIProvider()` method has been documented to throw `IllegalStateException` on repeated calls since version 1.0, but since version 2.0, the implementation in fact didn't honor this documentation. Multiple implementations started to silently depend on repeated `setCDIProvider()` calls being allowed, especially for testing.

We previously [1][2] fixed the implementation to actually do what it documents, planning to release the fix in CDI 4.1, but it turns out this is very inconvenient. Therefore, this commit makes repeated calls of `setCDIProvider()` officially allowed. For consistency, it also allows repeated calls of `BuildServicesResolver.setBuildServices()`.

[1] https://github.com/jakartaee/cdi/commit/82ec5d71872212364a321cd3700d0ecadf9162d2
[2] https://github.com/jakartaee/cdi/commit/8ead70bdd135d277e277dfffc086b58dd92a1de3

Fixes #695