### PR TITLE
Relax the scope requirement for public fields

### DIFF
--- a/spec/src/main/asciidoc/core/implementation.asciidoc
+++ b/spec/src/main/asciidoc/core/implementation.asciidoc
@@ -20,8 +20,8 @@ A _managed bean_ is a bean that is implemented by a Java class.
 This class is called the _bean class_ of the managed bean.
 The basic lifecycle and semantics of managed beans are defined by the Managed Beans specification.
 
-
-If a managed bean has a non-static public field, it must have scope `@Dependent`. If a managed bean with a non-static public field declares any scope other than `@Dependent`, the container automatically detects the problem and treats it as a definition error.
+If a managed bean has a non-static public field, its scope must be a <<normal_scope,pseudo-scope>> (for example, `@Dependent` or `@Singleton`).
+If a managed bean with a non-static public field declares a normal scope, the container automatically detects the problem and treats it as a definition error.
 
 If the managed bean class is a generic type, it must have scope `@Dependent`. If a managed bean with a parameterized bean class declares any scope other than `@Dependent`, the container automatically detects the problem and treats it as a definition error.
 


### PR DESCRIPTION
Currently, the specification says that non-`@Dependent` beans may not have public fields. This is overly restrictive; in particular, implementing this rule precisely precludes passing the AtInject TCK, where `@Singleton` beans have public fields.

This commit relaxes the requirement: all pseudo-scoped beans may have public fields; normal scoped beans may not. This makes most sense, it is what all existing implementations do (checked ArC, Weld and OpenWebBeans) and it is how the TCK is already written.

Fixes #660