### PR TITLE
Add API for programmatic access to assignability rules for observer methods and typesafe resolution.

### DIFF
--- a/api/src/main/java/jakarta/enterprise/inject/spi/BeanContainer.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/BeanContainer.java
@@ -251,4 +251,40 @@ public interface BeanContainer {
      * @since 2.0
      */
     Instance<Object> createInstance();
+
+    /**
+     * Returns true if a bean with given bean types and qualifiers would be assignable
+     * to an injection point with given required type and required qualifiers, false otherwise.
+     * <p>
+     * Callers do not need to include implied qualifiers ({@code @Default}, {@code Any}).
+     * These will be automatically added where applicable.
+     * <p>
+     * Throws {@link IllegalArgumentException} if any of the arguments is {@code null}.
+     *
+     * @param beanTypes bean types of a bean; must not be {@code null}
+     * @param beanQualifiers qualifiers of a bean; must not be {@code null}
+     * @param requiredType required type of an injection point; must not be {@code null}
+     * @param requiredQualifiers required qualifiers of an injection point; must not be {@code null}
+     * @return true if a bean with given bean types and qualifiers would be assignable
+     * to an injection point with given required type and required qualifiers, false otherwise
+     */
+    boolean isMatchingBean(Set<Type> beanTypes, Set<Annotation> beanQualifiers, Type requiredType, Set<Annotation> requiredQualifiers);
+
+    /**
+     * Returns true if an event object with given type and qualifiers would match
+     * an observer method with given observed event type and observed event qualifiers, false otherwise.
+     * <p>
+     * Callers do not need to include implied qualifiers ({@code @Default}, {@code Any}).
+     * These will be automatically added where applicable.
+     * <p>
+     * Throws {@link IllegalArgumentException} if any of the arguments is {@code null}.
+     *
+     * @param eventType type of an event object; must not be {@code null}
+     * @param eventQualifiers event qualifiers; must not be {@code null}
+     * @param observedEventType observed event type of an observer method; must not be {@code null}
+     * @param observedEventQualifiers observed event qualifiers on an observer method; must not be {@code null}
+     * @return true if an event object with given type and qualifiers would result in notifying
+     * an observer method with given observed event type and observed event qualifiers, false otherwise
+     */
+    boolean isMatchingEvent(Type eventType, Set<Annotation> eventQualifiers, Type observedEventType, Set<Annotation> observedEventQualifiers);
 }

--- a/spec/src/main/asciidoc/core/beanmanager_lite.asciidoc
+++ b/spec/src/main/asciidoc/core/beanmanager_lite.asciidoc
@@ -260,3 +260,14 @@ Instance<Object> createInstance();
 Instances of dependent scoped beans obtained with this `Instance` object must be explicitly released by calling `Instance.destroy()` method.
 
 If no qualifier is passed to `Instance.select()` method, the `@Default` qualifier is assumed.
+
+==== Assignability of beans and observers
+
+The methods `BeanContainer.isMatchingBean()` and `isMatchingObserver()` provide access to assignability rules defined in <<typesafe_resolution>> and <<observer_resolution>>.
+
+[source, java]
+----
+public boolean isMatchingBean(Set<Type> beanTypes, Set<Annotation> beanQualifiers, Type requiredType, Set<Annotation> requiredQualifiers);
+
+public boolean isMatchingEvent(Type eventType, Set<Annotation> eventQualifiers, Type observedEventType, Set<Annotation> observedEventQualifiers);
+----


### PR DESCRIPTION
Fixes #498 

There was a request to have access to CDI assignability rules programmatically so this is the first thing coming to my mind.
**I am not 100% convinced that this feature is very useful (in that it can find some audience) so I would appreciate some feedback on whether we want to add it or not.**

Few notes:
* Delegate assignability is deliberately left out as I cannot imagine anyone extending that.
* The varargs argument for qualifiers might instead be a collection because there isn't really a case where this could be entirely left out due to presence of `@Default` - at least not the way it's worded right now as users are expected to list all required qualifiers.
* We could use the `TypesAndQualifiers` to also represent the event payload/qualifiers and injection point type/qualifiers but I somehow found it cleaner this way as the required type would always be a singleton set.