### PR TITLE
Fix typo in javadoc

### DIFF
--- a/lang-model/pom.xml
+++ b/lang-model/pom.xml
@@ -92,7 +92,7 @@
 					</header>
 					<bottom><![CDATA[
 Comments to: <a href="mailto:cdi-dev@eclipse.org">cdi-dev@eclipse.org</a>.<br>
-Copyright &#169; 2018,2020 Eclipse Foundation.<br>
+Copyright &#169; 2018,2023 Eclipse Foundation.<br>
 Use is subject to <a href="{@docRoot}/doc-files/speclicense.html" target="_top">license terms</a>.]]>
 					</bottom>
 				</configuration>

--- a/lang-model/src/main/java/jakarta/enterprise/lang/model/declarations/MethodInfo.java
+++ b/lang-model/src/main/java/jakarta/enterprise/lang/model/declarations/MethodInfo.java
@@ -20,7 +20,7 @@ public interface MethodInfo extends DeclarationInfo {
     /**
      * Returns a list of {@linkplain ParameterInfo parameters} declared or implicitly declared on this method.
      *
-     * @return immutable list of {@linkplain ParameterInfo parameterts}, never {@code null}
+     * @return immutable list of {@linkplain ParameterInfo parameters}, never {@code null}
      */
     List<ParameterInfo> parameters();
 


### PR DESCRIPTION
This is a very minor fix for a typo in javadoc 

