### PR TITLE
Remove mention of context activation from AfterDeploymentValidation event

### DIFF
--- a/spec/src/main/asciidoc/core/spi_full.asciidoc
+++ b/spec/src/main/asciidoc/core/spi_full.asciidoc
@@ -1081,7 +1081,7 @@ With `ObserverMethodConfigurator` you can perform the following operations:
 
 ==== `AfterDeploymentValidation` event
 
-The container must fire an event after it has validated that there are no deployment problems and before creating contexts or processing requests.
+The container must fire an event after it has validated that there are no deployment problems and before processing requests.
 
 The event object must be of type `jakarta.enterprise.inject.spi.AfterDeploymentValidation`:
 


### PR DESCRIPTION
Fixes #454 

This doesn't change functionality, just removes a bit of text potentially causing confusion.
While it is true that contexts aren't activated before this event, there is nothing preventing impls from activating them within this event. In fact, `BM#getReference` explicitly allows to resolve all beans at this point which means you have to be able to activate contexts anyway.