### PR TITLE
Update CI setup - add JDK 21, bump versions on actions

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -2,7 +2,7 @@ name: Jakarta Contexts and Dependency Injection CI
 
 on:
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:
@@ -11,12 +11,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ '11', '17' ]
+        java: [ '11', '17', '21' ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4.1.1
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v1.4.3
+        uses: actions/setup-java@v3.13.0
         with:
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
       - name: "Maven install"
         run: |


### PR DESCRIPTION
CI is still pointing towards `master` when we now have `main`.
We can also add newer JDK and update deps.