### PR TITLE
Add entry for jdk 21 into Github Actions building matrix 

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         java: [ '11', '17' ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4.1.1
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v1.4.3
         with:

--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ '11', '17' ]
+        java: [ '11', '17', '21' ]
     steps:
       - uses: actions/checkout@v4.1.1
       - name: Set up JDK ${{ matrix.java }}

--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -15,8 +15,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.1
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v1.4.3
+        uses: actions/setup-java@v3.13.0
         with:
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
       - name: "Maven install"
         run: |


### PR DESCRIPTION
The main purpose of this pull request is to add an entry for building the project using JDK 21 with and update of github actions tools for checkout and build project 


