### PR TITLE
Tweaks to Bean and Event Assignability API

### DIFF
--- a/api/src/main/java/jakarta/enterprise/inject/spi/BeanContainer.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/BeanContainer.java
@@ -255,10 +255,10 @@ public interface BeanContainer {
     Instance<Object> createInstance();
 
     /**
-     * Returns true if a bean with given bean types and qualifiers would be assignable
-     * to an injection point with given required type and required qualifiers, false otherwise.
+     * Returns {@code true} if a bean with given bean types and qualifiers would be assignable
+     * to an injection point with given required type and required qualifiers, {@code false} otherwise.
      * <p>
-     * Callers do not need to include implied qualifiers ({@code @Default}, {@code Any}).
+     * Callers do not need to include implied qualifiers ({@code @Default}, {@code @Any}).
      * These will be automatically added where applicable.
      * <p>
      * Throws {@link IllegalArgumentException} if any of the arguments is {@code null}.
@@ -267,18 +267,18 @@ public interface BeanContainer {
      * @param beanQualifiers qualifiers of a bean; must not be {@code null}
      * @param requiredType required type of an injection point; must not be {@code null}
      * @param requiredQualifiers required qualifiers of an injection point; must not be {@code null}
-     * @return true if a bean with given bean types and qualifiers would be assignable
-     *         to an injection point with given required type and required qualifiers, false otherwise
+     * @return {@code true} if a bean with given bean types and qualifiers would be assignable
+     *         to an injection point with given required type and required qualifiers, {@code false} otherwise
      */
     boolean isMatchingBean(Set<Type> beanTypes, Set<Annotation> beanQualifiers, Type requiredType,
             Set<Annotation> requiredQualifiers);
 
     /**
-     * Returns true if an event object with given type and qualifiers would match
-     * an observer method with given observed event type and observed event qualifiers, false otherwise.
+     * Returns {@code true} if an event object with given type and qualifiers would match
+     * an observer method with given observed event type and observed event qualifiers, {@code false} otherwise.
      * <p>
-     * Callers do not need to include implied qualifiers ({@code @Default}, {@code Any}).
-     * These will be automatically added where applicable.
+     * Callers do not need to include the implied qualifier ({@code @Any}).
+     * It will be automatically added where applicable.
      * <p>
      * Throws {@link IllegalArgumentException} if any of the arguments is {@code null}.
      *
@@ -286,8 +286,8 @@ public interface BeanContainer {
      * @param eventQualifiers event qualifiers; must not be {@code null}
      * @param observedEventType observed event type of an observer method; must not be {@code null}
      * @param observedEventQualifiers observed event qualifiers on an observer method; must not be {@code null}
-     * @return true if an event object with given type and qualifiers would result in notifying
-     *         an observer method with given observed event type and observed event qualifiers, false otherwise
+     * @return {@code true} if an event object with given type and qualifiers would result in notifying
+     *         an observer method with given observed event type and observed event qualifiers, {@code false} otherwise
      */
     boolean isMatchingEvent(Type eventType, Set<Annotation> eventQualifiers, Type observedEventType,
             Set<Annotation> observedEventQualifiers);

--- a/spec/src/main/asciidoc/core/beanmanager_lite.asciidoc
+++ b/spec/src/main/asciidoc/core/beanmanager_lite.asciidoc
@@ -261,9 +261,11 @@ Instances of dependent scoped beans obtained with this `Instance` object must be
 
 If no qualifier is passed to `Instance.select()` method, the `@Default` qualifier is assumed.
 
-==== Assignability of beans and observers
+[[bm_bean_event_assignability]]
 
-The methods `BeanContainer.isMatchingBean()` and `isMatchingObserver()` provide access to assignability rules defined in <<typesafe_resolution>> and <<observer_resolution>>.
+==== Assignability of beans and events
+
+The methods `BeanContainer.isMatchingBean()` and `isMatchingEvent()` provide access to assignability rules defined in <<typesafe_resolution>> and <<observer_resolution>>.
 
 [source, java]
 ----


### PR DESCRIPTION
Follow up to #700 with a few things I noticed while writing TCKs in jakartaee/cdi-tck#526:

* use code tags for true and false
* consistently use @ with annotation classes in javadoc
* fix wrong method name in spec
* add anchor name to spec
* no implied `Default` qualifier for events
* Change "beans and observers" to "beans and events" in spec for consistency

Relates to issue #498 