### PR TITLE
Document and add copyright headers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,10 @@
+# Copyright (c) {year} Contributors to the Eclipse Foundation
+# 
+# This program and the accompanying materials are made available under the
+# Apache Software License 2.0 which is available at:
+# https://www.apache.org/licenses/LICENSE-2.0.
+# 
+# SPDX-License-Identifier: Apache-2.0
 version: 2
 updates:
   - package-ecosystem: github-actions

--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -1,3 +1,10 @@
+# Copyright (c) 2021 Red Hat, Inc. and others
+# 
+# This program and the accompanying materials are made available under the
+# Apache Software License 2.0 which is available at:
+# https://www.apache.org/licenses/LICENSE-2.0.
+# 
+# SPDX-License-Identifier: Apache-2.0
 name: Jakarta Contexts and Dependency Injection CI
 
 on:

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -49,7 +49,7 @@ Contributor Agreement (ECA) on file.
 For more information, please see the Eclipse Committer Handbook:
 https://www.eclipse.org/projects/handbook/#resources-commit
 
-## Eclipse Development Process
+== Eclipse Development Process
 
 This Eclipse Foundation open project is governed by the Eclipse Foundation
 Development Process and operates under the terms of the Eclipse IP Policy.
@@ -63,6 +63,32 @@ Jakarta EE specification projects.
 * https://www.eclipse.org/org/documents/Eclipse_IP_Policy.pdf
 * https://jakarta.ee/about/jesp/
 * https://www.eclipse.org/legal/efsp_non_assert.php
+
+== Copyright headers
+
+Every new file should start with one of the following headers in whatever comment format is appropriate for the file, where `{year}` is the year the file was created and `{owner}` is the copyright owner of the original contribution:
+
+[source]
+----
+Copyright (c) {year} Contributors to the Eclipse Foundation
+
+This program and the accompanying materials are made available under the
+Apache Software License 2.0 which is available at:
+https://www.apache.org/licenses/LICENSE-2.0.
+
+SPDX-License-Identifier: Apache-2.0
+----
+
+[source]
+----
+Copyright (c) {year} {owner} and others
+
+This program and the accompanying materials are made available under the
+Apache Software License 2.0 which is available at:
+https://www.apache.org/licenses/LICENSE-2.0.
+
+SPDX-License-Identifier: Apache-2.0
+----
 
 == Contact
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+<!--
+    Copyright (c) 2011 Red Hat, Inc. and others
+    
+    This program and the accompanying materials are made available under the
+    Apache Software License 2.0 which is available at:
+    https://www.apache.org/licenses/LICENSE-2.0.
+    
+    SPDX-License-Identifier: Apache-2.0
+-->
 
 # GitHub Pages
 The latest news for CDI 4.x can be found in the [GitHub pages](https://jakartaee.github.io/cdi/)

--- a/api/src/ide/eclipse/jboss_community_formatter.xml
+++ b/api/src/ide/eclipse/jboss_community_formatter.xml
@@ -1,4 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+    Copyright (c) 2011 Red Hat, Inc. and others
+    
+    This program and the accompanying materials are made available under the
+    Apache Software License 2.0 which is available at:
+    https://www.apache.org/licenses/LICENSE-2.0.
+    
+    SPDX-License-Identifier: Apache-2.0
+-->
 <profiles version="11">
 <profile kind="CodeFormatterProfile" name="JBoss Community" version="11">
 <setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_before_root_tags" value="insert"/>

--- a/api/src/main/javadoc/overview.html
+++ b/api/src/main/javadoc/overview.html
@@ -1,3 +1,12 @@
+<!--
+    Copyright (c) 2011 Red Hat, Inc. and others
+    
+    This program and the accompanying materials are made available under the
+    Apache Software License 2.0 which is available at:
+    https://www.apache.org/licenses/LICENSE-2.0.
+    
+    SPDX-License-Identifier: Apache-2.0
+-->
 <html>
 
 <body>

--- a/api/src/test/resources/full-beans-1_1.xml
+++ b/api/src/test/resources/full-beans-1_1.xml
@@ -1,4 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2012 Red Hat, Inc. and others
+    
+    This program and the accompanying materials are made available under the
+    Apache Software License 2.0 which is available at:
+    https://www.apache.org/licenses/LICENSE-2.0.
+    
+    SPDX-License-Identifier: Apache-2.0
+-->
 <beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xsi:schemaLocation="

--- a/api/src/test/resources/java.policy
+++ b/api/src/test/resources/java.policy
@@ -1,4 +1,12 @@
-
+/*
+ * Copyright (c) 2018 Red Hat, Inc. and others
+ * 
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ * 
+ * SPDX-License-Identifier: Apache-2.0
+ */
 // Standard extensions get all permissions by default
 
 grant codeBase "file:${{java.ext.dirs}}/*" {

--- a/docs/404.html
+++ b/docs/404.html
@@ -1,3 +1,12 @@
+<!--
+    Copyright (c) 2021 Red Hat, Inc. and others
+    
+    This program and the accompanying materials are made available under the
+    Apache Software License 2.0 which is available at:
+    https://www.apache.org/licenses/LICENSE-2.0.
+    
+    SPDX-License-Identifier: Apache-2.0
+-->
 ---
 permalink: /404.html
 layout: default

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,3 +1,10 @@
+# Copyright (c) 2021 Red Hat, Inc. and others
+# 
+# This program and the accompanying materials are made available under the
+# Apache Software License 2.0 which is available at:
+# https://www.apache.org/licenses/LICENSE-2.0.
+# 
+# SPDX-License-Identifier: Apache-2.0
 source "https://rubygems.org"
 # Hello! This is where you manage which Jekyll version is used to run.
 # When you want to use a different version, change it below, save the

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,12 @@
+<!--
+    Copyright (c) 2021 Red Hat, Inc. and others
+    
+    This program and the accompanying materials are made available under the
+    Apache Software License 2.0 which is available at:
+    https://www.apache.org/licenses/LICENSE-2.0.
+    
+    SPDX-License-Identifier: Apache-2.0
+-->
 # Jakarta CDI Website Based on Jekyll
 
 ## Getting Started

--- a/docs/_authors/asd.md
+++ b/docs/_authors/asd.md
@@ -1,3 +1,12 @@
+<!--
+    Copyright (c) 2021 Red Hat, Inc. and others
+    
+    This program and the accompanying materials are made available under the
+    Apache Software License 2.0 which is available at:
+    https://www.apache.org/licenses/LICENSE-2.0.
+    
+    SPDX-License-Identifier: Apache-2.0
+-->
 ---
 short_name: asd
 name: Antoine Sabot-Durand

--- a/docs/_authors/ladt.md
+++ b/docs/_authors/ladt.md
@@ -1,3 +1,12 @@
+<!--
+    Copyright (c) 2021 Red Hat, Inc. and others
+    
+    This program and the accompanying materials are made available under the
+    Apache Software License 2.0 which is available at:
+    https://www.apache.org/licenses/LICENSE-2.0.
+    
+    SPDX-License-Identifier: Apache-2.0
+-->
 ---
 short_name: ladt
 name: Ladislav Thon

--- a/docs/_authors/matn.md
+++ b/docs/_authors/matn.md
@@ -1,3 +1,12 @@
+<!--
+    Copyright (c) 2021 Red Hat, Inc. and others
+    
+    This program and the accompanying materials are made available under the
+    Apache Software License 2.0 which is available at:
+    https://www.apache.org/licenses/LICENSE-2.0.
+    
+    SPDX-License-Identifier: Apache-2.0
+-->
 ---
 short_name: matn
 name: Matej Novotny

--- a/docs/_authors/starksm.md
+++ b/docs/_authors/starksm.md
@@ -1,3 +1,12 @@
+<!--
+    Copyright (c) 2021 Red Hat, Inc. and others
+    
+    This program and the accompanying materials are made available under the
+    Apache Software License 2.0 which is available at:
+    https://www.apache.org/licenses/LICENSE-2.0.
+    
+    SPDX-License-Identifier: Apache-2.0
+-->
 ---
 short_name: starksm
 name: Scott M Stark

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,3 +1,10 @@
+# Copyright (c) 2021 Red Hat, Inc. and others
+# 
+# This program and the accompanying materials are made available under the
+# Apache Software License 2.0 which is available at:
+# https://www.apache.org/licenses/LICENSE-2.0.
+# 
+# SPDX-License-Identifier: Apache-2.0
 # Welcome to Jekyll!
 #
 # This config file is meant for settings that affect your whole blog, values

--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -1,3 +1,10 @@
+# Copyright (c) 2021 Red Hat, Inc. and others
+# 
+# This program and the accompanying materials are made available under the
+# Apache Software License 2.0 which is available at:
+# https://www.apache.org/licenses/LICENSE-2.0.
+# 
+# SPDX-License-Identifier: Apache-2.0
 - name: Home
   link: /
 - name: About

--- a/docs/_layouts/author.html
+++ b/docs/_layouts/author.html
@@ -1,3 +1,12 @@
+<!--
+    Copyright (c) 2021 Red Hat, Inc. and others
+    
+    This program and the accompanying materials are made available under the
+    Apache Software License 2.0 which is available at:
+    https://www.apache.org/licenses/LICENSE-2.0.
+    
+    SPDX-License-Identifier: Apache-2.0
+-->
 ---
 layout: default
 ---

--- a/docs/_layouts/post.html
+++ b/docs/_layouts/post.html
@@ -1,3 +1,12 @@
+<!--
+    Copyright (c) 2021 Red Hat, Inc. and others
+    
+    This program and the accompanying materials are made available under the
+    Apache Software License 2.0 which is available at:
+    https://www.apache.org/licenses/LICENSE-2.0.
+    
+    SPDX-License-Identifier: Apache-2.0
+-->
 ---
 layout: default
 ---

--- a/docs/_posts/2021-10-25-pages-here.md
+++ b/docs/_posts/2021-10-25-pages-here.md
@@ -1,3 +1,12 @@
+<!--
+    Copyright (c) 2021 Red Hat, Inc. and others
+    
+    This program and the accompanying materials are made available under the
+    Apache Software License 2.0 which is available at:
+    https://www.apache.org/licenses/LICENSE-2.0.
+    
+    SPDX-License-Identifier: Apache-2.0
+-->
 ---
 layout: post
 title:  "Jakarta CDI GitHub Pages"

--- a/docs/_posts/2021-10-25-way-to-cdi4.md
+++ b/docs/_posts/2021-10-25-way-to-cdi4.md
@@ -1,3 +1,12 @@
+<!--
+    Copyright (c) 2021 Red Hat, Inc. and others
+    
+    This program and the accompanying materials are made available under the
+    Apache Software License 2.0 which is available at:
+    https://www.apache.org/licenses/LICENSE-2.0.
+    
+    SPDX-License-Identifier: Apache-2.0
+-->
 ---
 title: "On the Way to CDI 4.0"
 summary: Overview of changes coming to CDI 4.0

--- a/docs/_posts/2021-12-03-you-know-build-compatible-extensions.md
+++ b/docs/_posts/2021-12-03-you-know-build-compatible-extensions.md
@@ -1,3 +1,12 @@
+<!--
+    Copyright (c) 2021 Red Hat, Inc. and others
+    
+    This program and the accompanying materials are made available under the
+    Apache Software License 2.0 which is available at:
+    https://www.apache.org/licenses/LICENSE-2.0.
+    
+    SPDX-License-Identifier: Apache-2.0
+-->
 ---
 title: "You already know Build Compatible Extensions"
 summary: Comparison of Portable Extensions and Build Compatible Extensions

--- a/docs/_posts/2022-01-24-400-RC3-spec.md
+++ b/docs/_posts/2022-01-24-400-RC3-spec.md
@@ -1,3 +1,12 @@
+<!--
+    Copyright (c) 2022 Red Hat, Inc. and others
+    
+    This program and the accompanying materials are made available under the
+    Apache Software License 2.0 which is available at:
+    https://www.apache.org/licenses/LICENSE-2.0.
+    
+    SPDX-License-Identifier: Apache-2.0
+-->
 ---
 layout: post
 title:  "Jakarta CDI 4.0 Draft Specification"

--- a/docs/about.md
+++ b/docs/about.md
@@ -1,3 +1,12 @@
+<!--
+    Copyright (c) 2021 Red Hat, Inc. and others
+    
+    This program and the accompanying materials are made available under the
+    Apache Software License 2.0 which is available at:
+    https://www.apache.org/licenses/LICENSE-2.0.
+    
+    SPDX-License-Identifier: Apache-2.0
+-->
 ---
 layout: page
 title: About

--- a/docs/authors.html
+++ b/docs/authors.html
@@ -1,3 +1,12 @@
+<!--
+    Copyright (c) 2021 Red Hat, Inc. and others
+    
+    This program and the accompanying materials are made available under the
+    Apache Software License 2.0 which is available at:
+    https://www.apache.org/licenses/LICENSE-2.0.
+    
+    SPDX-License-Identifier: Apache-2.0
+-->
 ---
 layout: default
 title: Authors

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,12 @@
+<!--
+    Copyright (c) 2021 Red Hat, Inc. and others
+    
+    This program and the accompanying materials are made available under the
+    Apache Software License 2.0 which is available at:
+    https://www.apache.org/licenses/LICENSE-2.0.
+    
+    SPDX-License-Identifier: Apache-2.0
+-->
 ---
 # Feel free to add content and custom Front Matter to this file.
 # To modify the layout, see https://jekyllrb.com/docs/themes/#overriding-theme-defaults

--- a/el/pom.xml
+++ b/el/pom.xml
@@ -1,3 +1,12 @@
+<!--
+	Copyright (c) 2023 Red Hat, Inc. and others
+	
+	This program and the accompanying materials are made available under the
+	Apache Software License 2.0 which is available at:
+	https://www.apache.org/licenses/LICENSE-2.0.
+	
+	SPDX-License-Identifier: Apache-2.0
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 

--- a/el/src/main/javadoc/overview.html
+++ b/el/src/main/javadoc/overview.html
@@ -1,3 +1,12 @@
+<!--
+    Copyright (c) 2023 Red Hat, Inc. and others
+    
+    This program and the accompanying materials are made available under the
+    Apache Software License 2.0 which is available at:
+    https://www.apache.org/licenses/LICENSE-2.0.
+    
+    SPDX-License-Identifier: Apache-2.0
+-->
 <html>
 
 <body>

--- a/ide-config/pom.xml
+++ b/ide-config/pom.xml
@@ -1,4 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+	Copyright (c) 2023 Red Hat, Inc. and others
+	
+	This program and the accompanying materials are made available under the
+	Apache Software License 2.0 which is available at:
+	https://www.apache.org/licenses/LICENSE-2.0.
+	
+	SPDX-License-Identifier: Apache-2.0
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/ide-config/src/main/resources/cdi-format.xml
+++ b/ide-config/src/main/resources/cdi-format.xml
@@ -1,4 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+    Copyright (c) 2023 Red Hat, Inc. and others
+    
+    This program and the accompanying materials are made available under the
+    Apache Software License 2.0 which is available at:
+    https://www.apache.org/licenses/LICENSE-2.0.
+    
+    SPDX-License-Identifier: Apache-2.0
+-->
 <profiles version="15">
 <profile kind="CodeFormatterProfile" name="CDI" version="15">
 <setting id="org.eclipse.jdt.core.formatter.align_assignment_statements_on_columns" value="false"/>

--- a/ide-config/src/main/resources/cdi.importorder
+++ b/ide-config/src/main/resources/cdi.importorder
@@ -1,3 +1,10 @@
+# Copyright (c) 2023 Red Hat, Inc. and others
+# 
+# This program and the accompanying materials are made available under the
+# Apache Software License 2.0 which is available at:
+# https://www.apache.org/licenses/LICENSE-2.0.
+# 
+# SPDX-License-Identifier: Apache-2.0
 #Organize Import Order
 0=java
 1=javax

--- a/lang-model/pom.xml
+++ b/lang-model/pom.xml
@@ -1,3 +1,12 @@
+<!--
+	Copyright (c) 2021 Red Hat, Inc. and others
+	
+	This program and the accompanying materials are made available under the
+	Apache Software License 2.0 which is available at:
+	https://www.apache.org/licenses/LICENSE-2.0.
+	
+	SPDX-License-Identifier: Apache-2.0
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 

--- a/lang-model/src/main/javadoc/overview.html
+++ b/lang-model/src/main/javadoc/overview.html
@@ -1,3 +1,12 @@
+<!--
+    Copyright (c) 2021 Red Hat, Inc. and others
+    
+    This program and the accompanying materials are made available under the
+    Apache Software License 2.0 which is available at:
+    https://www.apache.org/licenses/LICENSE-2.0.
+    
+    SPDX-License-Identifier: Apache-2.0
+-->
 <html>
 
 <body>

--- a/pom.xml
+++ b/pom.xml
@@ -99,8 +99,6 @@
 						<!-- files which are themselves licenses -->
 						<exclude>**/speclicense.html</exclude>
 						<exclude>**/license-*.asciidoc</exclude>
-						<!-- docs -->
-						<exclude>docs/**</exclude>
 					</excludes>
 				</configuration>
 				<executions>

--- a/pom.xml
+++ b/pom.xml
@@ -1,3 +1,12 @@
+<!--
+    Copyright (c) 2011 Red Hat, Inc. and others
+    
+    This program and the accompanying materials are made available under the
+    Apache Software License 2.0 which is available at:
+    https://www.apache.org/licenses/LICENSE-2.0.
+    
+    SPDX-License-Identifier: Apache-2.0
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -80,9 +80,19 @@
 				<artifactId>apache-rat-plugin</artifactId>
 				<version>${rat.version}</version>
 				<configuration>
-					<includes>
-						<include>**/*.java</include>
-					</includes>
+					<excludes>
+						<!-- files which are generated or otherwise can't have copyright headers -->
+						<exclude>**/.cache/**</exclude>
+						<exclude>**/*.lock</exclude>
+						<exclude>src/main/asciidoc/dictionary.txt</exclude>
+						<!-- services files -->
+						<exclude>**/resources/META-INF/services/*</exclude>
+						<!-- files which are themselves licenses -->
+						<exclude>**/speclicense.html</exclude>
+						<exclude>**/license-*.asciidoc</exclude>
+						<!-- docs -->
+						<exclude>docs/**</exclude>
+					</excludes>
 				</configuration>
 				<executions>
 					<execution>

--- a/spec/README.adoc
+++ b/spec/README.adoc
@@ -1,3 +1,12 @@
+////
+Copyright (c) 2015 Red Hat, Inc. and others
+
+This program and the accompanying materials are made available under the
+Apache Software License 2.0 which is available at:
+https://www.apache.org/licenses/LICENSE-2.0.
+
+SPDX-License-Identifier: Apache-2.0
+////
 = CDI Specification document generation
 
 This module contains AsciiDoc sources and configuration to generate CDI documentation in HTML and PDF format for both Apache License 2 and Jakarta Eclipse Foundation Specification Process.

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -1,3 +1,12 @@
+<!--
+	Copyright (c) 2014 Red Hat, Inc. and others
+	
+	This program and the accompanying materials are made available under the
+	Apache Software License 2.0 which is available at:
+	https://www.apache.org/licenses/LICENSE-2.0.
+	
+	SPDX-License-Identifier: Apache-2.0
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 

--- a/spec/src/main/asciidoc/architecture.asciidoc
+++ b/spec/src/main/asciidoc/architecture.asciidoc
@@ -1,3 +1,12 @@
+////
+Copyright (c) 2015 Red Hat, Inc. and others
+
+This program and the accompanying materials are made available under the
+Apache Software License 2.0 which is available at:
+https://www.apache.org/licenses/LICENSE-2.0.
+
+SPDX-License-Identifier: Apache-2.0
+////
 [[architecture]]
 == Architecture
 

--- a/spec/src/main/asciidoc/cdi-spec.asciidoc
+++ b/spec/src/main/asciidoc/cdi-spec.asciidoc
@@ -1,3 +1,12 @@
+////
+Copyright (c) 2015 Red Hat, Inc. and others
+
+This program and the accompanying materials are made available under the
+Apache Software License 2.0 which is available at:
+https://www.apache.org/licenses/LICENSE-2.0.
+
+SPDX-License-Identifier: Apache-2.0
+////
 = Jakarta Contexts and Dependency Injection
 :author: Jakarta Contexts and Dependency Injection Specification Project
 :email: cdi-dev@eclipse.org

--- a/spec/src/main/asciidoc/core/beanmanager_lite.asciidoc
+++ b/spec/src/main/asciidoc/core/beanmanager_lite.asciidoc
@@ -1,3 +1,12 @@
+////
+Copyright (c) 2021 Red Hat, Inc. and others
+
+This program and the accompanying materials are made available under the
+Apache Software License 2.0 which is available at:
+https://www.apache.org/licenses/LICENSE-2.0.
+
+SPDX-License-Identifier: Apache-2.0
+////
 [[programmatic_access]]
 
 == Programmatic access to container

--- a/spec/src/main/asciidoc/core/core_structure.adoc
+++ b/spec/src/main/asciidoc/core/core_structure.adoc
@@ -1,3 +1,12 @@
+////
+Copyright (c) 2022 Red Hat, Inc. and others
+
+This program and the accompanying materials are made available under the
+Apache Software License 2.0 which is available at:
+https://www.apache.org/licenses/LICENSE-2.0.
+
+SPDX-License-Identifier: Apache-2.0
+////
 :numbered!:
 
 == Structure

--- a/spec/src/main/asciidoc/core/decorators.asciidoc
+++ b/spec/src/main/asciidoc/core/decorators.asciidoc
@@ -1,3 +1,12 @@
+////
+Copyright (c) 2015 Red Hat, Inc. and others
+
+This program and the accompanying materials are made available under the
+Apache Software License 2.0 which is available at:
+https://www.apache.org/licenses/LICENSE-2.0.
+
+SPDX-License-Identifier: Apache-2.0
+////
 [[decorators]]
 
 == Decorators

--- a/spec/src/main/asciidoc/core/definition.asciidoc
+++ b/spec/src/main/asciidoc/core/definition.asciidoc
@@ -1,3 +1,12 @@
+////
+Copyright (c) 2015 Red Hat, Inc. and others
+
+This program and the accompanying materials are made available under the
+Apache Software License 2.0 which is available at:
+https://www.apache.org/licenses/LICENSE-2.0.
+
+SPDX-License-Identifier: Apache-2.0
+////
 [[concepts]]
 
 == Concepts

--- a/spec/src/main/asciidoc/core/definition_full.asciidoc
+++ b/spec/src/main/asciidoc/core/definition_full.asciidoc
@@ -1,3 +1,12 @@
+////
+Copyright (c) 2021 Red Hat, Inc. and others
+
+This program and the accompanying materials are made available under the
+Apache Software License 2.0 which is available at:
+https://www.apache.org/licenses/LICENSE-2.0.
+
+SPDX-License-Identifier: Apache-2.0
+////
 [partintro]
 --
 {cdi_full} contains all the functionality defined in {cdi_lite} and adds some additional features such as specialization, decorators, session scope or conversation scope.

--- a/spec/src/main/asciidoc/core/events.asciidoc
+++ b/spec/src/main/asciidoc/core/events.asciidoc
@@ -1,3 +1,12 @@
+////
+Copyright (c) 2015 Red Hat, Inc. and others
+
+This program and the accompanying materials are made available under the
+Apache Software License 2.0 which is available at:
+https://www.apache.org/licenses/LICENSE-2.0.
+
+SPDX-License-Identifier: Apache-2.0
+////
 [[events]]
 
 == Events

--- a/spec/src/main/asciidoc/core/events_full.asciidoc
+++ b/spec/src/main/asciidoc/core/events_full.asciidoc
@@ -1,3 +1,12 @@
+////
+Copyright (c) 2021 Red Hat, Inc. and others
+
+This program and the accompanying materials are made available under the
+Apache Software License 2.0 which is available at:
+https://www.apache.org/licenses/LICENSE-2.0.
+
+SPDX-License-Identifier: Apache-2.0
+////
 [[events_full]]
 
 == Events in {cdi_full}

--- a/spec/src/main/asciidoc/core/implementation.asciidoc
+++ b/spec/src/main/asciidoc/core/implementation.asciidoc
@@ -1,3 +1,12 @@
+////
+Copyright (c) 2015 Red Hat, Inc. and others
+
+This program and the accompanying materials are made available under the
+Apache Software License 2.0 which is available at:
+https://www.apache.org/licenses/LICENSE-2.0.
+
+SPDX-License-Identifier: Apache-2.0
+////
 [[implementation]]
 
 == Programming model

--- a/spec/src/main/asciidoc/core/inheritance.asciidoc
+++ b/spec/src/main/asciidoc/core/inheritance.asciidoc
@@ -1,3 +1,12 @@
+////
+Copyright (c) 2015 Red Hat, Inc. and others
+
+This program and the accompanying materials are made available under the
+Apache Software License 2.0 which is available at:
+https://www.apache.org/licenses/LICENSE-2.0.
+
+SPDX-License-Identifier: Apache-2.0
+////
 [[inheritance]]
 
 == Inheritance

--- a/spec/src/main/asciidoc/core/inheritance_full.asciidoc
+++ b/spec/src/main/asciidoc/core/inheritance_full.asciidoc
@@ -1,3 +1,12 @@
+////
+Copyright (c) 2021 Red Hat, Inc. and others
+
+This program and the accompanying materials are made available under the
+Apache Software License 2.0 which is available at:
+https://www.apache.org/licenses/LICENSE-2.0.
+
+SPDX-License-Identifier: Apache-2.0
+////
 [[inheritance_full]]
 
 == Inheritance and specialization in {cdi_full}

--- a/spec/src/main/asciidoc/core/injectionandresolution.asciidoc
+++ b/spec/src/main/asciidoc/core/injectionandresolution.asciidoc
@@ -1,3 +1,12 @@
+////
+Copyright (c) 2015 Red Hat, Inc. and others
+
+This program and the accompanying materials are made available under the
+Apache Software License 2.0 which is available at:
+https://www.apache.org/licenses/LICENSE-2.0.
+
+SPDX-License-Identifier: Apache-2.0
+////
 [[injection_and_resolution]]
 
 == Dependency injection and lookup

--- a/spec/src/main/asciidoc/core/injectionandresolution_full.asciidoc
+++ b/spec/src/main/asciidoc/core/injectionandresolution_full.asciidoc
@@ -1,3 +1,12 @@
+////
+Copyright (c) 2021 Red Hat, Inc. and others
+
+This program and the accompanying materials are made available under the
+Apache Software License 2.0 which is available at:
+https://www.apache.org/licenses/LICENSE-2.0.
+
+SPDX-License-Identifier: Apache-2.0
+////
 [[injection_and_resolution_full]]
 
 == Dependency injection and lookup in {cdi_full}

--- a/spec/src/main/asciidoc/core/interceptors.asciidoc
+++ b/spec/src/main/asciidoc/core/interceptors.asciidoc
@@ -1,3 +1,12 @@
+////
+Copyright (c) 2015 Red Hat, Inc. and others
+
+This program and the accompanying materials are made available under the
+Apache Software License 2.0 which is available at:
+https://www.apache.org/licenses/LICENSE-2.0.
+
+SPDX-License-Identifier: Apache-2.0
+////
 [[interceptors]]
 
 == Interceptor bindings

--- a/spec/src/main/asciidoc/core/interceptors_full.asciidoc
+++ b/spec/src/main/asciidoc/core/interceptors_full.asciidoc
@@ -1,3 +1,12 @@
+////
+Copyright (c) 2021 Red Hat, Inc. and others
+
+This program and the accompanying materials are made available under the
+Apache Software License 2.0 which is available at:
+https://www.apache.org/licenses/LICENSE-2.0.
+
+SPDX-License-Identifier: Apache-2.0
+////
 [[interceptors_full]]
 
 == Interceptor bindings in {cdi_full}

--- a/spec/src/main/asciidoc/core/invokers.asciidoc
+++ b/spec/src/main/asciidoc/core/invokers.asciidoc
@@ -1,3 +1,12 @@
+////
+Copyright (c) 2023 Red Hat, Inc. and others
+
+This program and the accompanying materials are made available under the
+Apache Software License 2.0 which is available at:
+https://www.apache.org/licenses/LICENSE-2.0.
+
+SPDX-License-Identifier: Apache-2.0
+////
 [[method_invokers]]
 == Method invokers
 

--- a/spec/src/main/asciidoc/core/invokers_full.asciidoc
+++ b/spec/src/main/asciidoc/core/invokers_full.asciidoc
@@ -1,3 +1,12 @@
+////
+Copyright (c) 2023 Red Hat, Inc. and others
+
+This program and the accompanying materials are made available under the
+Apache Software License 2.0 which is available at:
+https://www.apache.org/licenses/LICENSE-2.0.
+
+SPDX-License-Identifier: Apache-2.0
+////
 [[method_invokers_full]]
 == Method invokers in {cdi_full}
 

--- a/spec/src/main/asciidoc/core/lifecycle.asciidoc
+++ b/spec/src/main/asciidoc/core/lifecycle.asciidoc
@@ -1,3 +1,12 @@
+////
+Copyright (c) 2015 Red Hat, Inc. and others
+
+This program and the accompanying materials are made available under the
+Apache Software License 2.0 which is available at:
+https://www.apache.org/licenses/LICENSE-2.0.
+
+SPDX-License-Identifier: Apache-2.0
+////
 [[lifecycle]]
 
 == Lifecycle of contextual instances

--- a/spec/src/main/asciidoc/core/lifecycle_full.asciidoc
+++ b/spec/src/main/asciidoc/core/lifecycle_full.asciidoc
@@ -1,3 +1,12 @@
+////
+Copyright (c) 2021 Red Hat, Inc. and others
+
+This program and the accompanying materials are made available under the
+Apache Software License 2.0 which is available at:
+https://www.apache.org/licenses/LICENSE-2.0.
+
+SPDX-License-Identifier: Apache-2.0
+////
 [[lifecycle_full]]
 
 == Lifecycle of contextual instances in {cdi_full}

--- a/spec/src/main/asciidoc/core/packagingdeployment.asciidoc
+++ b/spec/src/main/asciidoc/core/packagingdeployment.asciidoc
@@ -1,3 +1,12 @@
+////
+Copyright (c) 2015 Red Hat, Inc. and others
+
+This program and the accompanying materials are made available under the
+Apache Software License 2.0 which is available at:
+https://www.apache.org/licenses/LICENSE-2.0.
+
+SPDX-License-Identifier: Apache-2.0
+////
 [[packaging_deployment]]
 
 == Packaging and deployment

--- a/spec/src/main/asciidoc/core/packagingdeployment_full.asciidoc
+++ b/spec/src/main/asciidoc/core/packagingdeployment_full.asciidoc
@@ -1,3 +1,12 @@
+////
+Copyright (c) 2021 Red Hat, Inc. and others
+
+This program and the accompanying materials are made available under the
+Apache Software License 2.0 which is available at:
+https://www.apache.org/licenses/LICENSE-2.0.
+
+SPDX-License-Identifier: Apache-2.0
+////
 [[packaging_deployment_full]]
 
 == Packaging and deployment in {cdi_full}

--- a/spec/src/main/asciidoc/core/scopescontexts.asciidoc
+++ b/spec/src/main/asciidoc/core/scopescontexts.asciidoc
@@ -1,3 +1,12 @@
+////
+Copyright (c) 2015 Red Hat, Inc. and others
+
+This program and the accompanying materials are made available under the
+Apache Software License 2.0 which is available at:
+https://www.apache.org/licenses/LICENSE-2.0.
+
+SPDX-License-Identifier: Apache-2.0
+////
 [[contexts]]
 
 == Scopes and contexts

--- a/spec/src/main/asciidoc/core/scopescontexts_full.asciidoc
+++ b/spec/src/main/asciidoc/core/scopescontexts_full.asciidoc
@@ -1,3 +1,12 @@
+////
+Copyright (c) 2021 Red Hat, Inc. and others
+
+This program and the accompanying materials are made available under the
+Apache Software License 2.0 which is available at:
+https://www.apache.org/licenses/LICENSE-2.0.
+
+SPDX-License-Identifier: Apache-2.0
+////
 [[contexts_full]]
 
 == Scopes and contexts in {cdi_full}

--- a/spec/src/main/asciidoc/core/spi_full.asciidoc
+++ b/spec/src/main/asciidoc/core/spi_full.asciidoc
@@ -1,3 +1,12 @@
+////
+Copyright (c) 2021 Red Hat, Inc. and others
+
+This program and the accompanying materials are made available under the
+Apache Software License 2.0 which is available at:
+https://www.apache.org/licenses/LICENSE-2.0.
+
+SPDX-License-Identifier: Apache-2.0
+////
 [[spi_full]]
 
 == Portable extensions

--- a/spec/src/main/asciidoc/core/spi_lite.asciidoc
+++ b/spec/src/main/asciidoc/core/spi_lite.asciidoc
@@ -1,3 +1,12 @@
+////
+Copyright (c) 2021 Red Hat, Inc. and others
+
+This program and the accompanying materials are made available under the
+Apache Software License 2.0 which is available at:
+https://www.apache.org/licenses/LICENSE-2.0.
+
+SPDX-License-Identifier: Apache-2.0
+////
 [[spi_lite]]
 
 == Build compatible extensions

--- a/spec/src/main/asciidoc/docinfo.html
+++ b/spec/src/main/asciidoc/docinfo.html
@@ -1,3 +1,12 @@
+<!--
+    Copyright (c) 2017 Red Hat, Inc. and others
+    
+    This program and the accompanying materials are made available under the
+    Apache Software License 2.0 which is available at:
+    https://www.apache.org/licenses/LICENSE-2.0.
+    
+    SPDX-License-Identifier: Apache-2.0
+-->
 <!-- Generate a nice TOC -->
 <script src="https://code.jquery.com/jquery-1.11.3.min.js"></script>
 <script src="https://code.jquery.com/ui/1.11.4/jquery-ui.min.js"></script>

--- a/spec/src/main/asciidoc/javaee/decorators_ee.asciidoc
+++ b/spec/src/main/asciidoc/javaee/decorators_ee.asciidoc
@@ -1,3 +1,12 @@
+////
+Copyright (c) 2015 Red Hat, Inc. and others
+
+This program and the accompanying materials are made available under the
+Apache Software License 2.0 which is available at:
+https://www.apache.org/licenses/LICENSE-2.0.
+
+SPDX-License-Identifier: Apache-2.0
+////
 [[decorators_ee]]
 
 == Decorators in Jakarta EE

--- a/spec/src/main/asciidoc/javaee/definition_ee.asciidoc
+++ b/spec/src/main/asciidoc/javaee/definition_ee.asciidoc
@@ -1,3 +1,12 @@
+////
+Copyright (c) 2015 Red Hat, Inc. and others
+
+This program and the accompanying materials are made available under the
+Apache Software License 2.0 which is available at:
+https://www.apache.org/licenses/LICENSE-2.0.
+
+SPDX-License-Identifier: Apache-2.0
+////
 [[concepts_ee]]
 
 == Extended Concepts for Jakarta EE

--- a/spec/src/main/asciidoc/javaee/el.asciidoc
+++ b/spec/src/main/asciidoc/javaee/el.asciidoc
@@ -1,3 +1,12 @@
+////
+Copyright (c) 2023 Red Hat, Inc. and others
+
+This program and the accompanying materials are made available under the
+Apache Software License 2.0 which is available at:
+https://www.apache.org/licenses/LICENSE-2.0.
+
+SPDX-License-Identifier: Apache-2.0
+////
 [[el]]
 == Integration with Unified EL
 

--- a/spec/src/main/asciidoc/javaee/events_ee.asciidoc
+++ b/spec/src/main/asciidoc/javaee/events_ee.asciidoc
@@ -1,3 +1,12 @@
+////
+Copyright (c) 2015 Red Hat, Inc. and others
+
+This program and the accompanying materials are made available under the
+Apache Software License 2.0 which is available at:
+https://www.apache.org/licenses/LICENSE-2.0.
+
+SPDX-License-Identifier: Apache-2.0
+////
 [[events_ee]]
 
 == Events in Jakarta EE

--- a/spec/src/main/asciidoc/javaee/implementation_ee.asciidoc
+++ b/spec/src/main/asciidoc/javaee/implementation_ee.asciidoc
@@ -1,3 +1,12 @@
+////
+Copyright (c) 2015 Red Hat, Inc. and others
+
+This program and the accompanying materials are made available under the
+Apache Software License 2.0 which is available at:
+https://www.apache.org/licenses/LICENSE-2.0.
+
+SPDX-License-Identifier: Apache-2.0
+////
 [[implementation_ee]]
 
 == Addition to programming model for Jakarta EE

--- a/spec/src/main/asciidoc/javaee/inheritance_ee.asciidoc
+++ b/spec/src/main/asciidoc/javaee/inheritance_ee.asciidoc
@@ -1,3 +1,12 @@
+////
+Copyright (c) 2015 Red Hat, Inc. and others
+
+This program and the accompanying materials are made available under the
+Apache Software License 2.0 which is available at:
+https://www.apache.org/licenses/LICENSE-2.0.
+
+SPDX-License-Identifier: Apache-2.0
+////
 [[type_level_inheritance_ee]]
 
 === Inheritance of type-level metadata in Jakarta EE

--- a/spec/src/main/asciidoc/javaee/injectionandresolution_ee.asciidoc
+++ b/spec/src/main/asciidoc/javaee/injectionandresolution_ee.asciidoc
@@ -1,3 +1,12 @@
+////
+Copyright (c) 2015 Red Hat, Inc. and others
+
+This program and the accompanying materials are made available under the
+Apache Software License 2.0 which is available at:
+https://www.apache.org/licenses/LICENSE-2.0.
+
+SPDX-License-Identifier: Apache-2.0
+////
 [[injection_el_resolution_ee]]
 
 == Dependency injection, lookup and EL in Jakarta EE

--- a/spec/src/main/asciidoc/javaee/interceptors_ee.asciidoc
+++ b/spec/src/main/asciidoc/javaee/interceptors_ee.asciidoc
@@ -1,3 +1,12 @@
+////
+Copyright (c) 2015 Red Hat, Inc. and others
+
+This program and the accompanying materials are made available under the
+Apache Software License 2.0 which is available at:
+https://www.apache.org/licenses/LICENSE-2.0.
+
+SPDX-License-Identifier: Apache-2.0
+////
 [[interceptors_ee]]
 
 == Interceptor bindings in Jakarta EE

--- a/spec/src/main/asciidoc/javaee/javaeeintegration.asciidoc
+++ b/spec/src/main/asciidoc/javaee/javaeeintegration.asciidoc
@@ -1,3 +1,12 @@
+////
+Copyright (c) 2015 Red Hat, Inc. and others
+
+This program and the accompanying materials are made available under the
+Apache Software License 2.0 which is available at:
+https://www.apache.org/licenses/LICENSE-2.0.
+
+SPDX-License-Identifier: Apache-2.0
+////
 [partintro]
 --
 This part of the document specifies additional rules or features when using CDI in a Jakarta EE container.

--- a/spec/src/main/asciidoc/javaee/lifecycle_ee.asciidoc
+++ b/spec/src/main/asciidoc/javaee/lifecycle_ee.asciidoc
@@ -1,3 +1,12 @@
+////
+Copyright (c) 2015 Red Hat, Inc. and others
+
+This program and the accompanying materials are made available under the
+Apache Software License 2.0 which is available at:
+https://www.apache.org/licenses/LICENSE-2.0.
+
+SPDX-License-Identifier: Apache-2.0
+////
 [[lifecycle_ee]]
 
 == Lifecycle of contextual instances

--- a/spec/src/main/asciidoc/javaee/packagingdeployment_ee.asciidoc
+++ b/spec/src/main/asciidoc/javaee/packagingdeployment_ee.asciidoc
@@ -1,3 +1,12 @@
+////
+Copyright (c) 2015 Red Hat, Inc. and others
+
+This program and the accompanying materials are made available under the
+Apache Software License 2.0 which is available at:
+https://www.apache.org/licenses/LICENSE-2.0.
+
+SPDX-License-Identifier: Apache-2.0
+////
 [[packaging_deployment_ee]]
 
 == Packaging and deployment in Jakarta EE

--- a/spec/src/main/asciidoc/javaee/scopescontext_ee.asciidoc
+++ b/spec/src/main/asciidoc/javaee/scopescontext_ee.asciidoc
@@ -1,3 +1,12 @@
+////
+Copyright (c) 2015 Red Hat, Inc. and others
+
+This program and the accompanying materials are made available under the
+Apache Software License 2.0 which is available at:
+https://www.apache.org/licenses/LICENSE-2.0.
+
+SPDX-License-Identifier: Apache-2.0
+////
 [[contexts_ee]]
 
 == Scopes and contexts in Jakarta EE

--- a/spec/src/main/asciidoc/javaee/spi_ee.asciidoc
+++ b/spec/src/main/asciidoc/javaee/spi_ee.asciidoc
@@ -1,3 +1,12 @@
+////
+Copyright (c) 2015 Red Hat, Inc. and others
+
+This program and the accompanying materials are made available under the
+Apache Software License 2.0 which is available at:
+https://www.apache.org/licenses/LICENSE-2.0.
+
+SPDX-License-Identifier: Apache-2.0
+////
 [[spi_ee]]
 
 == Portable extensions in Jakarta EE

--- a/spec/src/main/asciidoc/javase/bootstrap_se.asciidoc
+++ b/spec/src/main/asciidoc/javase/bootstrap_se.asciidoc
@@ -1,3 +1,12 @@
+////
+Copyright (c) 2015 Red Hat, Inc. and others
+
+This program and the accompanying materials are made available under the
+Apache Software License 2.0 which is available at:
+https://www.apache.org/licenses/LICENSE-2.0.
+
+SPDX-License-Identifier: Apache-2.0
+////
 [[se_bootstrap]]
 
 == Bootstrapping a CDI container in Java SE

--- a/spec/src/main/asciidoc/javase/javase.asciidoc
+++ b/spec/src/main/asciidoc/javase/javase.asciidoc
@@ -1,3 +1,12 @@
+////
+Copyright (c) 2015 Red Hat, Inc. and others
+
+This program and the accompanying materials are made available under the
+Apache Software License 2.0 which is available at:
+https://www.apache.org/licenses/LICENSE-2.0.
+
+SPDX-License-Identifier: Apache-2.0
+////
 [partintro]
 --
 This part of the document specifies additional rules and features when using CDI in Java SE.

--- a/spec/src/main/asciidoc/javase/packagingdeployment_se.asciidoc
+++ b/spec/src/main/asciidoc/javase/packagingdeployment_se.asciidoc
@@ -1,3 +1,12 @@
+////
+Copyright (c) 2015 Red Hat, Inc. and others
+
+This program and the accompanying materials are made available under the
+Apache Software License 2.0 which is available at:
+https://www.apache.org/licenses/LICENSE-2.0.
+
+SPDX-License-Identifier: Apache-2.0
+////
 [[packaging_deployment_se]]
 
 == Packaging and deployment in Java SE

--- a/spec/src/main/asciidoc/javase/scopescontext_se.asciidoc
+++ b/spec/src/main/asciidoc/javase/scopescontext_se.asciidoc
@@ -1,3 +1,12 @@
+////
+Copyright (c) 2015 Red Hat, Inc. and others
+
+This program and the accompanying materials are made available under the
+Apache Software License 2.0 which is available at:
+https://www.apache.org/licenses/LICENSE-2.0.
+
+SPDX-License-Identifier: Apache-2.0
+////
 [[contexts_se]]
 
 == Scopes and contexts in Java SE

--- a/spec/src/main/asciidoc/javase/spi_se.asciidoc
+++ b/spec/src/main/asciidoc/javase/spi_se.asciidoc
@@ -1,3 +1,12 @@
+////
+Copyright (c) 2016 Red Hat, Inc. and others
+
+This program and the accompanying materials are made available under the
+Apache Software License 2.0 which is available at:
+https://www.apache.org/licenses/LICENSE-2.0.
+
+SPDX-License-Identifier: Apache-2.0
+////
 [[spi_se]]
 
 == Portable extensions in Java SE

--- a/spec/src/main/asciidoc/preface.asciidoc
+++ b/spec/src/main/asciidoc/preface.asciidoc
@@ -1,3 +1,12 @@
+////
+Copyright (c) 2015 Red Hat, Inc. and others
+
+This program and the accompanying materials are made available under the
+Apache Software License 2.0 which is available at:
+https://www.apache.org/licenses/LICENSE-2.0.
+
+SPDX-License-Identifier: Apache-2.0
+////
 :numbered!:
 :license: asl2
 ["preface",sectnum="0"]


### PR DESCRIPTION
* document the correct copyright header in `CONTRIBUTING.adoc`
* add missing copyright headers in non-Java files

When reviewing, please particularly check that I haven't added a copyright header to something that shouldn't have one. The areas I wasn't sure about were:

- the spec asciidoc files - it looks like we build the spec with an Apache license, except for when we do a final release when we use the EFSL, so guessed that the Apache license for the source files is correct.
- the `docs` directory which builds https://jakartaee.github.io/cdi/
- the `.github` directry
- the files in `ide-support` and `jboss_community_formatter.xml` - I don't know how these were developed, they may have come form another project and probably started from the defaults of the the software that creates them?

I **haven't** changed any headers on existing files and I've used the format that includes the original author's name since some of the files pre-date involvement with the Eclipse Foundation.

<details>
    <summary>Script used to generate headers</summary>

It's a bit rough, some files needed fixed up by hand, particularly XML ones since the `<?xml` line must be first if present.

```bash
#!/bin/bash

format_header () {
    local top=$1
    local prefix=$2
    local bottom=$3
    local owner=$4
    local year=$5

    commands=()
    if [[ -n "$top" ]]; then
        commands+=("-e" "1i ${top}")
    fi
    if [[ -n "$prefix" ]]; then
        commands+=("-e" "s%^%${prefix}%")
    fi
    if [[ -n "$bottom" ]]; then
        commands+=("-e" "\$a ${bottom}")
    fi

    sed "${commands[@]}" <<END
Copyright (c) ${year} ${owner} and others

This program and the accompanying materials are made available under the
Apache Software License 2.0 which is available at:
https://www.apache.org/licenses/LICENSE-2.0.

SPDX-License-Identifier: Apache-2.0
END
}

add_header() {
    echo "$1" | cat - "$2" > tmp.txt
    mv tmp.txt "$2"
}

missing_extensions=()

for F in $(grep -h ????? target/rat.txt | sed -e 's| !????? ||') ; do

    data=$(git log --format="%ae %as" $F | tail -1)

    if [[ $data =~ redhat || $data =~ starksm || $data =~ pmuir || $data =~ antoine || $data =~ marlow || $data =~ gegastaldi || $data =~ ladicek ]] ; then
        company="Red Hat, Inc."
    elif [[ $data =~ ibm ]] ; then
        company="IBM Corp."
    else
        echo "No known owner for $F, who is $data"
    fi

    year=$(echo $data | cut -d ' ' -f 2 | cut -d '-' -f 1)

    filename=$(basename "$F")
    extension="${filename##*.}"

    if [[ $extension == asciidoc || $extension == adoc ]] ; then
        header=$(format_header "////" "" "////" "$company" "$year")
    elif [[ $extension == xml || $extension == html || $extension == md ]] ; then
        header=$(format_header "<!--" "    " "-->" "$company" "$year")
    elif [[ $extension == yml || $extension == Gemfile || $extension == importorder ]] ; then
        header=$(format_header "" "# " "" "$company" "$year")
    elif [[ $extension == java || $extension == policy ]] ; then
        header=$(format_header "/*" " * " "\\ */" "$company" "$year")
    else
        header="Unknown format: $extension"
        missing_extensions+=("$extension")
    fi

    add_header "$header" "$F"
done

declare -A uniq_ext
for ext in "${missing_extensions[@]}"
do
    uniq_ext[$ext]=0
done

echo "missing extensions: " "${!uniq_ext[@]}"
```
</details>

Fixes #741 