### PR TITLE
Set a version for the resources plugin

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -382,6 +382,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-resources-plugin</artifactId>
+				<version>${maven-resources-plugin.version}</version>
 				<executions>
 					<execution>
 						<id>filter-overview</id>

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,7 @@
 
 		<maven-bundle-plugin.version>5.1.9</maven-bundle-plugin.version>
 		<maven-compiler-plugin.version>3.12.1</maven-compiler-plugin.version>
+		<maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
 		<maven-surefire-plugin.version>3.2.2</maven-surefire-plugin.version>
 
 		<!-- Formatting versions and config -->


### PR DESCRIPTION
I missed this in #745 and maven outputs the following warning on every build:

```
[INFO] Scanning for projects...
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for jakarta.enterprise:jakarta.enterprise.cdi-api:jar:4.1.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-resources-plugin is missing. @ line 382, column 12
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
```