### PR TITLE
Bring copyright headers into agreement with NOTICE

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -1,8 +1,6 @@
 <!--
   ~ JBoss, Home of Professional Open Source
   ~ Copyright 2018, Red Hat, Inc., and individual contributors
-  ~ by the @authors tag. See the copyright.txt in the distribution for a
-  ~ full listing of individual contributors.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -1,5 +1,4 @@
 <!--
-  ~ JBoss, Home of Professional Open Source
   ~ Copyright 2018, Red Hat, Inc., and individual contributors
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");

--- a/api/src/main/java/jakarta/decorator/Decorator.java
+++ b/api/src/main/java/jakarta/decorator/Decorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/decorator/Delegate.java
+++ b/api/src/main/java/jakarta/decorator/Delegate.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/decorator/package-info.java
+++ b/api/src/main/java/jakarta/decorator/package-info.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/context/ApplicationScoped.java
+++ b/api/src/main/java/jakarta/enterprise/context/ApplicationScoped.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/context/BeforeDestroyed.java
+++ b/api/src/main/java/jakarta/enterprise/context/BeforeDestroyed.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/context/BusyConversationException.java
+++ b/api/src/main/java/jakarta/enterprise/context/BusyConversationException.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/context/ContextException.java
+++ b/api/src/main/java/jakarta/enterprise/context/ContextException.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/context/ContextNotActiveException.java
+++ b/api/src/main/java/jakarta/enterprise/context/ContextNotActiveException.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/context/Conversation.java
+++ b/api/src/main/java/jakarta/enterprise/context/Conversation.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/context/ConversationScoped.java
+++ b/api/src/main/java/jakarta/enterprise/context/ConversationScoped.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/context/Dependent.java
+++ b/api/src/main/java/jakarta/enterprise/context/Dependent.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/context/Destroyed.java
+++ b/api/src/main/java/jakarta/enterprise/context/Destroyed.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/context/Initialized.java
+++ b/api/src/main/java/jakarta/enterprise/context/Initialized.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/context/NonexistentConversationException.java
+++ b/api/src/main/java/jakarta/enterprise/context/NonexistentConversationException.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/context/NormalScope.java
+++ b/api/src/main/java/jakarta/enterprise/context/NormalScope.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/context/RequestScoped.java
+++ b/api/src/main/java/jakarta/enterprise/context/RequestScoped.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/context/SessionScoped.java
+++ b/api/src/main/java/jakarta/enterprise/context/SessionScoped.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/context/control/ActivateRequestContext.java
+++ b/api/src/main/java/jakarta/enterprise/context/control/ActivateRequestContext.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/context/control/RequestContextController.java
+++ b/api/src/main/java/jakarta/enterprise/context/control/RequestContextController.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/context/package-info.java
+++ b/api/src/main/java/jakarta/enterprise/context/package-info.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/context/spi/AlterableContext.java
+++ b/api/src/main/java/jakarta/enterprise/context/spi/AlterableContext.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/context/spi/Context.java
+++ b/api/src/main/java/jakarta/enterprise/context/spi/Context.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/context/spi/Contextual.java
+++ b/api/src/main/java/jakarta/enterprise/context/spi/Contextual.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/context/spi/CreationalContext.java
+++ b/api/src/main/java/jakarta/enterprise/context/spi/CreationalContext.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/context/spi/package-info.java
+++ b/api/src/main/java/jakarta/enterprise/context/spi/package-info.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/event/Event.java
+++ b/api/src/main/java/jakarta/enterprise/event/Event.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/event/ImmutableNotificationOptions.java
+++ b/api/src/main/java/jakarta/enterprise/event/ImmutableNotificationOptions.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/event/NotificationOptions.java
+++ b/api/src/main/java/jakarta/enterprise/event/NotificationOptions.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/event/ObserverException.java
+++ b/api/src/main/java/jakarta/enterprise/event/ObserverException.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/event/Observes.java
+++ b/api/src/main/java/jakarta/enterprise/event/Observes.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/event/ObservesAsync.java
+++ b/api/src/main/java/jakarta/enterprise/event/ObservesAsync.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/event/Reception.java
+++ b/api/src/main/java/jakarta/enterprise/event/Reception.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/event/Shutdown.java
+++ b/api/src/main/java/jakarta/enterprise/event/Shutdown.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/event/Startup.java
+++ b/api/src/main/java/jakarta/enterprise/event/Startup.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/event/TransactionPhase.java
+++ b/api/src/main/java/jakarta/enterprise/event/TransactionPhase.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/event/package-info.java
+++ b/api/src/main/java/jakarta/enterprise/event/package-info.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/Alternative.java
+++ b/api/src/main/java/jakarta/enterprise/inject/Alternative.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/AmbiguousResolutionException.java
+++ b/api/src/main/java/jakarta/enterprise/inject/AmbiguousResolutionException.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/Any.java
+++ b/api/src/main/java/jakarta/enterprise/inject/Any.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/CreationException.java
+++ b/api/src/main/java/jakarta/enterprise/inject/CreationException.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/Decorated.java
+++ b/api/src/main/java/jakarta/enterprise/inject/Decorated.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/Default.java
+++ b/api/src/main/java/jakarta/enterprise/inject/Default.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/Disposes.java
+++ b/api/src/main/java/jakarta/enterprise/inject/Disposes.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/IllegalProductException.java
+++ b/api/src/main/java/jakarta/enterprise/inject/IllegalProductException.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/InjectionException.java
+++ b/api/src/main/java/jakarta/enterprise/inject/InjectionException.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/Instance.java
+++ b/api/src/main/java/jakarta/enterprise/inject/Instance.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/Intercepted.java
+++ b/api/src/main/java/jakarta/enterprise/inject/Intercepted.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/Model.java
+++ b/api/src/main/java/jakarta/enterprise/inject/Model.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/Produces.java
+++ b/api/src/main/java/jakarta/enterprise/inject/Produces.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/ResolutionException.java
+++ b/api/src/main/java/jakarta/enterprise/inject/ResolutionException.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/Specializes.java
+++ b/api/src/main/java/jakarta/enterprise/inject/Specializes.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/Stereotype.java
+++ b/api/src/main/java/jakarta/enterprise/inject/Stereotype.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/TransientReference.java
+++ b/api/src/main/java/jakarta/enterprise/inject/TransientReference.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/Typed.java
+++ b/api/src/main/java/jakarta/enterprise/inject/Typed.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/UnproxyableResolutionException.java
+++ b/api/src/main/java/jakarta/enterprise/inject/UnproxyableResolutionException.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/UnsatisfiedResolutionException.java
+++ b/api/src/main/java/jakarta/enterprise/inject/UnsatisfiedResolutionException.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/Vetoed.java
+++ b/api/src/main/java/jakarta/enterprise/inject/Vetoed.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/literal/InjectLiteral.java
+++ b/api/src/main/java/jakarta/enterprise/inject/literal/InjectLiteral.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2008, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/literal/NamedLiteral.java
+++ b/api/src/main/java/jakarta/enterprise/inject/literal/NamedLiteral.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2008, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/literal/QualifierLiteral.java
+++ b/api/src/main/java/jakarta/enterprise/inject/literal/QualifierLiteral.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2008, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/literal/SingletonLiteral.java
+++ b/api/src/main/java/jakarta/enterprise/inject/literal/SingletonLiteral.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2008, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/se/SeContainer.java
+++ b/api/src/main/java/jakarta/enterprise/inject/se/SeContainer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/se/SeContainerInitializer.java
+++ b/api/src/main/java/jakarta/enterprise/inject/se/SeContainerInitializer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/AfterBeanDiscovery.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/AfterBeanDiscovery.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/AfterDeploymentValidation.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/AfterDeploymentValidation.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/AfterTypeDiscovery.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/AfterTypeDiscovery.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/Annotated.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/Annotated.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/AnnotatedCallable.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/AnnotatedCallable.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/AnnotatedConstructor.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/AnnotatedConstructor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/AnnotatedField.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/AnnotatedField.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/AnnotatedMember.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/AnnotatedMember.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/AnnotatedMethod.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/AnnotatedMethod.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/AnnotatedParameter.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/AnnotatedParameter.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/AnnotatedType.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/AnnotatedType.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/Bean.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/Bean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/BeanAttributes.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/BeanAttributes.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/BeanContainer.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/BeanContainer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/BeanManager.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/BeanManager.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, 2013 Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/BeforeBeanDiscovery.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/BeforeBeanDiscovery.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/BeforeShutdown.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/BeforeShutdown.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/CDI.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/CDI.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/CDIProvider.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/CDIProvider.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, 2015 Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/Decorator.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/Decorator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/DefinitionException.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/DefinitionException.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/DeploymentException.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/DeploymentException.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/EventContext.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/EventContext.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016 Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/EventMetadata.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/EventMetadata.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, 2015 Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/Extension.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/Extension.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/InjectionPoint.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/InjectionPoint.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/InjectionTarget.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/InjectionTarget.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/InjectionTargetFactory.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/InjectionTargetFactory.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/InterceptionFactory.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/InterceptionFactory.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/InterceptionType.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/InterceptionType.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/Interceptor.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/Interceptor.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/ObserverMethod.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/ObserverMethod.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, 2015 Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/PassivationCapable.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/PassivationCapable.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/Prioritized.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/Prioritized.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/ProcessAnnotatedType.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/ProcessAnnotatedType.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/ProcessBean.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/ProcessBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/ProcessBeanAttributes.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/ProcessBeanAttributes.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/ProcessInjectionPoint.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/ProcessInjectionPoint.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/ProcessInjectionTarget.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/ProcessInjectionTarget.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/ProcessManagedBean.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/ProcessManagedBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/ProcessObserverMethod.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/ProcessObserverMethod.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/ProcessProducer.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/ProcessProducer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/ProcessProducerField.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/ProcessProducerField.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/ProcessProducerMethod.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/ProcessProducerMethod.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/ProcessSessionBean.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/ProcessSessionBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/ProcessSyntheticAnnotatedType.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/ProcessSyntheticAnnotatedType.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/ProcessSyntheticBean.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/ProcessSyntheticBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/ProcessSyntheticObserverMethod.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/ProcessSyntheticObserverMethod.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/Producer.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/Producer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/ProducerFactory.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/ProducerFactory.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/SecurityActions.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/SecurityActions.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2019, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +13,6 @@
  */
 /*
  * Copyright 2018, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.1-SNAPSHOT (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/SessionBeanType.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/SessionBeanType.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/Unmanaged.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/Unmanaged.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/WithAnnotations.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/WithAnnotations.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/configurator/AnnotatedConstructorConfigurator.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/configurator/AnnotatedConstructorConfigurator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/configurator/AnnotatedFieldConfigurator.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/configurator/AnnotatedFieldConfigurator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/configurator/AnnotatedMethodConfigurator.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/configurator/AnnotatedMethodConfigurator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/configurator/AnnotatedParameterConfigurator.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/configurator/AnnotatedParameterConfigurator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/configurator/AnnotatedTypeConfigurator.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/configurator/AnnotatedTypeConfigurator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/configurator/BeanAttributesConfigurator.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/configurator/BeanAttributesConfigurator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/configurator/BeanConfigurator.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/configurator/BeanConfigurator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/configurator/InjectionPointConfigurator.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/configurator/InjectionPointConfigurator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/configurator/ObserverMethodConfigurator.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/configurator/ObserverMethodConfigurator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/configurator/ProducerConfigurator.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/configurator/ProducerConfigurator.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/package-info.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/package-info.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/util/AnnotationLiteral.java
+++ b/api/src/main/java/jakarta/enterprise/util/AnnotationLiteral.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2018, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/util/Nonbinding.java
+++ b/api/src/main/java/jakarta/enterprise/util/Nonbinding.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/util/SecurityActions.java
+++ b/api/src/main/java/jakarta/enterprise/util/SecurityActions.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2019, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +13,6 @@
  */
 /*
  * Copyright 2018, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.1-SNAPSHOT (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/util/TypeLiteral.java
+++ b/api/src/main/java/jakarta/enterprise/util/TypeLiteral.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2010, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/jakarta/enterprise/util/package-info.java
+++ b/api/src/main/java/jakarta/enterprise/util/package-info.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2013, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/resources/beans_1_0.xsd
+++ b/api/src/main/resources/beans_1_0.xsd
@@ -2,8 +2,6 @@
 
    <!--
       Copyright 2008, Red Hat Middleware LLC, and individual contributors 
-      by the @authors tag. See the copyright.txt in the distribution for a
-      full listing of individual contributors.
 
       Licensed under the Apache License, Version 2.0 (the "License");
       you may not use this file except in compliance with the License.

--- a/api/src/main/resources/beans_1_1.xsd
+++ b/api/src/main/resources/beans_1_1.xsd
@@ -2,8 +2,6 @@
 
    <!--
       Copyright 2008, Red Hat Middleware LLC, and individual contributors 
-      by the @authors tag. See the copyright.txt in the distribution for a
-      full listing of individual contributors.
 
       Licensed under the Apache License, Version 2.0 (the "License");
       you may not use this file except in compliance with the License.

--- a/api/src/main/resources/beans_2_0.xsd
+++ b/api/src/main/resources/beans_2_0.xsd
@@ -2,8 +2,6 @@
 
 <!--
 ~ Copyright 2016, Red Hat, Inc., and individual contributors
-~ by the @authors tag. See the copyright.txt in the distribution for a
-~ full listing of individual contributors.
 ~
 ~ Licensed under the Apache License, Version 2.0 (the "License");
 ~ you may not use this file except in compliance with the License.

--- a/api/src/main/resources/beans_3_0.xsd
+++ b/api/src/main/resources/beans_3_0.xsd
@@ -2,8 +2,6 @@
 
 <!--
 ~ Copyright 2020, Red Hat, Inc., and individual contributors
-~ by the @authors tag. See the copyright.txt in the distribution for a
-~ full listing of individual contributors.
 ~
 ~ Licensed under the Apache License, Version 2.0 (the "License");
 ~ you may not use this file except in compliance with the License.

--- a/api/src/main/resources/beans_4_0.xsd
+++ b/api/src/main/resources/beans_4_0.xsd
@@ -2,8 +2,6 @@
 
 <!--
 ~ Copyright 2021, Red Hat, Inc., and individual contributors
-~ by the @authors tag. See the copyright.txt in the distribution for a
-~ full listing of individual contributors.
 ~
 ~ Licensed under the Apache License, Version 2.0 (the "License");
 ~ you may not use this file except in compliance with the License.

--- a/api/src/test/java/org/jboss/cdi/api/test/AnnotationLiteralTest.java
+++ b/api/src/test/java/org/jboss/cdi/api/test/AnnotationLiteralTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2011, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/test/java/org/jboss/cdi/api/test/CDITest.java
+++ b/api/src/test/java/org/jboss/cdi/api/test/CDITest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/test/java/org/jboss/cdi/api/test/ClosableCDIProvider.java
+++ b/api/src/test/java/org/jboss/cdi/api/test/ClosableCDIProvider.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/test/java/org/jboss/cdi/api/test/DummyCDIProvider.java
+++ b/api/src/test/java/org/jboss/cdi/api/test/DummyCDIProvider.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/test/java/org/jboss/cdi/api/test/DummyCDIProvider2.java
+++ b/api/src/test/java/org/jboss/cdi/api/test/DummyCDIProvider2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/test/java/org/jboss/cdi/api/test/DummyCDIProviderWithNullCDI.java
+++ b/api/src/test/java/org/jboss/cdi/api/test/DummyCDIProviderWithNullCDI.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2015, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/test/java/org/jboss/cdi/api/test/Foo.java
+++ b/api/src/test/java/org/jboss/cdi/api/test/Foo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2011, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/test/java/org/jboss/cdi/api/test/annotated/AbstractAnnotatedTest.java
+++ b/api/src/test/java/org/jboss/cdi/api/test/annotated/AbstractAnnotatedTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/test/java/org/jboss/cdi/api/test/annotated/AnnotatedCallableHolder.java
+++ b/api/src/test/java/org/jboss/cdi/api/test/annotated/AnnotatedCallableHolder.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/test/java/org/jboss/cdi/api/test/annotated/AnnotatedConstructorHolder.java
+++ b/api/src/test/java/org/jboss/cdi/api/test/annotated/AnnotatedConstructorHolder.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/test/java/org/jboss/cdi/api/test/annotated/AnnotatedConstructorTest.java
+++ b/api/src/test/java/org/jboss/cdi/api/test/annotated/AnnotatedConstructorTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/test/java/org/jboss/cdi/api/test/annotated/AnnotatedFieldHolder.java
+++ b/api/src/test/java/org/jboss/cdi/api/test/annotated/AnnotatedFieldHolder.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/test/java/org/jboss/cdi/api/test/annotated/AnnotatedFieldTest.java
+++ b/api/src/test/java/org/jboss/cdi/api/test/annotated/AnnotatedFieldTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/test/java/org/jboss/cdi/api/test/annotated/AnnotatedMemberHolder.java
+++ b/api/src/test/java/org/jboss/cdi/api/test/annotated/AnnotatedMemberHolder.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/test/java/org/jboss/cdi/api/test/annotated/AnnotatedMethodHolder.java
+++ b/api/src/test/java/org/jboss/cdi/api/test/annotated/AnnotatedMethodHolder.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/test/java/org/jboss/cdi/api/test/annotated/AnnotatedMethodTest.java
+++ b/api/src/test/java/org/jboss/cdi/api/test/annotated/AnnotatedMethodTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/test/java/org/jboss/cdi/api/test/annotated/AnnotatedParameterHolder.java
+++ b/api/src/test/java/org/jboss/cdi/api/test/annotated/AnnotatedParameterHolder.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/test/java/org/jboss/cdi/api/test/annotated/AnnotatedParameterTest.java
+++ b/api/src/test/java/org/jboss/cdi/api/test/annotated/AnnotatedParameterTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/test/java/org/jboss/cdi/api/test/annotated/AnnotatedTypeHolder.java
+++ b/api/src/test/java/org/jboss/cdi/api/test/annotated/AnnotatedTypeHolder.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/test/java/org/jboss/cdi/api/test/annotated/AnnotatedTypeTest.java
+++ b/api/src/test/java/org/jboss/cdi/api/test/annotated/AnnotatedTypeTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/test/java/org/jboss/cdi/api/test/annotated/RepeatBean.java
+++ b/api/src/test/java/org/jboss/cdi/api/test/annotated/RepeatBean.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/test/java/org/jboss/cdi/api/test/annotated/Repeater.java
+++ b/api/src/test/java/org/jboss/cdi/api/test/annotated/Repeater.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/test/java/org/jboss/cdi/api/test/annotated/Repeaters.java
+++ b/api/src/test/java/org/jboss/cdi/api/test/annotated/Repeaters.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/test/java/org/jboss/cdi/api/test/annotated/parameter/AnnotatedParameterTest.java
+++ b/api/src/test/java/org/jboss/cdi/api/test/annotated/parameter/AnnotatedParameterTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2014, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/test/java/org/jboss/cdi/api/test/event/NotificationOptionsTest.java
+++ b/api/src/test/java/org/jboss/cdi/api/test/event/NotificationOptionsTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/test/java/org/jboss/cdi/api/test/privileged/CDIPrivilegedTest.java
+++ b/api/src/test/java/org/jboss/cdi/api/test/privileged/CDIPrivilegedTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2018, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +13,6 @@
  */
 /*
  * Copyright 2018, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.1-SNAPSHOT (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/test/java/org/jboss/cdi/api/test/privileged/FakeCDIProvider.java
+++ b/api/src/test/java/org/jboss/cdi/api/test/privileged/FakeCDIProvider.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2018, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +13,6 @@
  */
 /*
  * Copyright 2018, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.1-SNAPSHOT (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/test/java/org/jboss/cdi/api/test/privileged/annotation/AnnotationLiteralTest.java
+++ b/api/src/test/java/org/jboss/cdi/api/test/privileged/annotation/AnnotationLiteralTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2018, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/test/java/org/jboss/cdi/api/test/privileged/annotation/MyAnnotation.java
+++ b/api/src/test/java/org/jboss/cdi/api/test/privileged/annotation/MyAnnotation.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2018, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/test/java/org/jboss/cdi/api/test/privileged/annotation/MyAnnotationLiteral.java
+++ b/api/src/test/java/org/jboss/cdi/api/test/privileged/annotation/MyAnnotationLiteral.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2018, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/test/java/org/jboss/cdi/api/test/se/DummySeContainerInitializer.java
+++ b/api/src/test/java/org/jboss/cdi/api/test/se/DummySeContainerInitializer.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/test/java/org/jboss/cdi/api/test/se/DummySeContainerInitializer2.java
+++ b/api/src/test/java/org/jboss/cdi/api/test/se/DummySeContainerInitializer2.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/test/java/org/jboss/cdi/api/test/se/SeContainerInitializerTest.java
+++ b/api/src/test/java/org/jboss/cdi/api/test/se/SeContainerInitializerTest.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2016, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/el/src/main/java/jakarta/enterprise/inject/spi/el/ELAwareBeanManager.java
+++ b/el/src/main/java/jakarta/enterprise/inject/spi/el/ELAwareBeanManager.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/el/src/main/java/module-info.java
+++ b/el/src/main/java/module-info.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2023, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lang-model/src/main/java/jakarta/enterprise/lang/model/AnnotationInfo.java
+++ b/lang-model/src/main/java/jakarta/enterprise/lang/model/AnnotationInfo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lang-model/src/main/java/jakarta/enterprise/lang/model/AnnotationMember.java
+++ b/lang-model/src/main/java/jakarta/enterprise/lang/model/AnnotationMember.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lang-model/src/main/java/jakarta/enterprise/lang/model/AnnotationTarget.java
+++ b/lang-model/src/main/java/jakarta/enterprise/lang/model/AnnotationTarget.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lang-model/src/main/java/jakarta/enterprise/lang/model/declarations/ClassInfo.java
+++ b/lang-model/src/main/java/jakarta/enterprise/lang/model/declarations/ClassInfo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lang-model/src/main/java/jakarta/enterprise/lang/model/declarations/DeclarationInfo.java
+++ b/lang-model/src/main/java/jakarta/enterprise/lang/model/declarations/DeclarationInfo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lang-model/src/main/java/jakarta/enterprise/lang/model/declarations/FieldInfo.java
+++ b/lang-model/src/main/java/jakarta/enterprise/lang/model/declarations/FieldInfo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lang-model/src/main/java/jakarta/enterprise/lang/model/declarations/MethodInfo.java
+++ b/lang-model/src/main/java/jakarta/enterprise/lang/model/declarations/MethodInfo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lang-model/src/main/java/jakarta/enterprise/lang/model/declarations/PackageInfo.java
+++ b/lang-model/src/main/java/jakarta/enterprise/lang/model/declarations/PackageInfo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lang-model/src/main/java/jakarta/enterprise/lang/model/declarations/ParameterInfo.java
+++ b/lang-model/src/main/java/jakarta/enterprise/lang/model/declarations/ParameterInfo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lang-model/src/main/java/jakarta/enterprise/lang/model/declarations/RecordComponentInfo.java
+++ b/lang-model/src/main/java/jakarta/enterprise/lang/model/declarations/RecordComponentInfo.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lang-model/src/main/java/jakarta/enterprise/lang/model/declarations/package-info.java
+++ b/lang-model/src/main/java/jakarta/enterprise/lang/model/declarations/package-info.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lang-model/src/main/java/jakarta/enterprise/lang/model/package-info.java
+++ b/lang-model/src/main/java/jakarta/enterprise/lang/model/package-info.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lang-model/src/main/java/jakarta/enterprise/lang/model/types/ArrayType.java
+++ b/lang-model/src/main/java/jakarta/enterprise/lang/model/types/ArrayType.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lang-model/src/main/java/jakarta/enterprise/lang/model/types/ClassType.java
+++ b/lang-model/src/main/java/jakarta/enterprise/lang/model/types/ClassType.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lang-model/src/main/java/jakarta/enterprise/lang/model/types/ParameterizedType.java
+++ b/lang-model/src/main/java/jakarta/enterprise/lang/model/types/ParameterizedType.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lang-model/src/main/java/jakarta/enterprise/lang/model/types/PrimitiveType.java
+++ b/lang-model/src/main/java/jakarta/enterprise/lang/model/types/PrimitiveType.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lang-model/src/main/java/jakarta/enterprise/lang/model/types/Type.java
+++ b/lang-model/src/main/java/jakarta/enterprise/lang/model/types/Type.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lang-model/src/main/java/jakarta/enterprise/lang/model/types/TypeVariable.java
+++ b/lang-model/src/main/java/jakarta/enterprise/lang/model/types/TypeVariable.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lang-model/src/main/java/jakarta/enterprise/lang/model/types/VoidType.java
+++ b/lang-model/src/main/java/jakarta/enterprise/lang/model/types/VoidType.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lang-model/src/main/java/jakarta/enterprise/lang/model/types/WildcardType.java
+++ b/lang-model/src/main/java/jakarta/enterprise/lang/model/types/WildcardType.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lang-model/src/main/java/jakarta/enterprise/lang/model/types/package-info.java
+++ b/lang-model/src/main/java/jakarta/enterprise/lang/model/types/package-info.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/lang-model/src/main/java/module-info.java
+++ b/lang-model/src/main/java/module-info.java
@@ -1,7 +1,5 @@
 /*
  * Copyright 2021, Red Hat, Inc., and individual contributors
- * by the @authors tag. See the copyright.txt in the distribution for a
- * full listing of individual contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Remove the references to the use of the `@authors` tag and copyright.txt
as a record of contributors.

NOTICE.md states that the source code repository logs should be used to
determine authorship.

Fixes #741 