### PR TITLE
Small corrections to project information files

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,93 @@
+# Community Code of Conduct
+
+**Version 2.0  
+January 1, 2023**
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as community members, contributors, Committers[^1], and Project Leads (collectively "Contributors") pledge to make participation in our projects and our community a harassment-free and inclusive experience for everyone.
+
+This Community Code of Conduct ("Code") outlines our behavior expectations as members of our community in all Eclipse Foundation activities, both offline and online. It is not intended to govern scenarios or behaviors outside of the scope of Eclipse Foundation activities. Nor is it intended to replace or supersede the protections offered to all our community members under the law. Please follow both the spirit and letter of this Code and encourage other Contributors to follow these principles into our work. Failure to read or acknowledge this Code does not excuse a Contributor from compliance with the Code.
+
+## Our Standards
+
+Examples of behavior that contribute to creating a positive and professional environment include:
+
+- Using welcoming and inclusive language;
+- Actively encouraging all voices;
+- Helping others bring their perspectives and listening actively. If you find yourself dominating a discussion, it is especially important to encourage other voices to join in;
+- Being respectful of differing viewpoints and experiences;
+- Gracefully accepting constructive criticism;
+- Focusing on what is best for the community;
+- Showing empathy towards other community members;
+- Being direct but professional; and
+- Leading by example by holding yourself and others accountable
+
+Examples of unacceptable behavior by Contributors include:
+
+- The use of sexualized language or imagery;
+- Unwelcome sexual attention or advances;
+- Trolling, insulting/derogatory comments, and personal or political attacks;
+- Public or private harassment, repeated harassment;
+- Publishing others' private information, such as a physical or electronic address, without explicit permission;
+- Violent threats or language directed against another person;
+- Sexist, racist, or otherwise discriminatory jokes and language;
+- Posting sexually explicit or violent material;
+- Sharing private content, such as emails sent privately or non-publicly, or unlogged forums such as IRC channel history;
+- Personal insults, especially those using racist or sexist terms;
+- Excessive or unnecessary profanity;
+- Advocating for, or encouraging, any of the above behavior; and
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+With the support of the Eclipse Foundation employees, consultants, officers, and directors (collectively, the "Staff"), Committers, and Project Leads, the Eclipse Foundation Conduct Committee (the "Conduct Committee") is responsible for clarifying the standards of acceptable behavior. The Conduct Committee takes appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+## Scope
+
+This Code applies within all Project, Working Group, and Interest Group spaces and communication channels of the Eclipse Foundation (collectively, "Eclipse spaces"), within any Eclipse-organized event or meeting, and in public spaces when an individual is representing an Eclipse Foundation Project, Working Group, Interest Group, or their communities. Examples of representing a Project or community include posting via an official social media account, personal accounts, or acting as an appointed representative at an online or offline event. Representation of Projects, Working Groups, and Interest Groups may be further defined and clarified by Committers, Project Leads, or the Staff.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the Conduct Committee via conduct@eclipse-foundation.org. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. Without the explicit consent of the reporter, the Conduct Committee is obligated to maintain confidentiality with regard to the reporter of an incident. The Conduct Committee is further obligated to ensure that the respondent is provided with sufficient information about the complaint to reply. If such details cannot be provided while maintaining confidentiality, the Conduct Committee will take the respondent‘s inability to provide a defense into account in its deliberations and decisions. Further details of enforcement guidelines may be posted separately.
+
+Staff, Committers and Project Leads have the right to report, remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code, or to block temporarily or permanently any Contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful. Any such actions will be reported to the Conduct Committee for transparency and record keeping.
+
+Any Staff (including officers and directors of the Eclipse Foundation), Committers, Project Leads, or Conduct Committee members who are the subject of a complaint to the Conduct Committee will be recused from the process of resolving any such complaint.
+
+## Responsibility
+
+The responsibility for administering this Code rests with the Conduct Committee, with oversight by the Executive Director and the Board of Directors. For additional information on the Conduct Committee and its process, please write to <conduct@eclipse-foundation.org>.
+
+## Investigation of Potential Code Violations
+
+All conflict is not bad as a healthy debate may sometimes be necessary to push us to do our best. It is, however, unacceptable to be disrespectful or offensive, or violate this Code. If you see someone engaging in objectionable behavior violating this Code, we encourage you to address the behavior directly with those involved. If for some reason, you are unable to resolve the matter or feel uncomfortable doing so, or if the behavior is threatening or harassing, please report it following the procedure laid out below.
+
+Reports should be directed to <conduct@eclipse-foundation.org>. It is the Conduct Committee’s role to receive and address reported violations of this Code and to ensure a fair and speedy resolution.
+
+The Eclipse Foundation takes all reports of potential Code violations seriously and is committed to confidentiality and a full investigation of all allegations. The identity of the reporter will be omitted from the details of the report supplied to the accused. Contributors who are being investigated for a potential Code violation will have an opportunity to be heard prior to any final determination. Those found to have violated the Code can seek reconsideration of the violation and disciplinary action decisions. Every effort will be made to have all matters disposed of within 60 days of the receipt of the complaint.
+
+## Actions
+Contributors who do not follow this Code in good faith may face temporary or permanent repercussions as determined by the Conduct Committee.
+
+This Code does not address all conduct. It works in conjunction with our [Communication Channel Guidelines](https://www.eclipse.org/org/documents/communication-channel-guidelines/), [Social Media Guidelines](https://www.eclipse.org/org/documents/social_media_guidelines.php), [Bylaws](https://www.eclipse.org/org/documents/eclipse-foundation-be-bylaws-en.pdf), and [Internal Rules](https://www.eclipse.org/org/documents/ef-be-internal-rules.pdf) which set out additional protections for, and obligations of, all contributors. The Foundation has additional policies that provide further guidance on other matters.
+
+It’s impossible to spell out every possible scenario that might be deemed a violation of this Code. Instead, we rely on one another’s good judgment to uphold a high standard of integrity within all Eclipse Spaces. Sometimes, identifying the right thing to do isn’t an easy call. In such a scenario, raise the issue as early as possible.
+
+## No Retaliation
+
+The Eclipse community relies upon and values the help of Contributors who identify potential problems that may need to be addressed within an Eclipse Space. Any retaliation against a Contributor who raises an issue honestly is a violation of this Code. That a Contributor has raised a concern honestly or participated in an investigation, cannot be the basis for any adverse action, including threats, harassment, or discrimination. If you work with someone who has raised a concern or provided information in an investigation, you should continue to treat the person with courtesy and respect. If you believe someone has retaliated against you, report the matter as described by this Code. Honest reporting does not mean that you have to be right when you raise a concern; you just have to believe that the information you are providing is accurate.
+
+False reporting, especially when intended to retaliate or exclude, is itself a violation of this Code and will not be accepted or tolerated.
+
+Everyone is encouraged to ask questions about this Code. Your feedback is welcome, and you will get a response within three business days. Write to <conduct@eclipse-foundation.org>.
+
+## Amendments
+
+The Eclipse Foundation Board of Directors may amend this Code from time to time and may vary the procedures it sets out where appropriate in a particular case.
+
+### Attribution
+
+This Code was inspired by the [Contributor Covenant](https://www.contributor-covenant.org/), version 1.4, available [here](https://www.contributor-covenant.org/version/1/4/code-of-conduct/).
+
+[^1]: Capitalized terms used herein without definition shall have the meanings assigned to them in the Bylaws.

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -18,13 +18,13 @@ cdi-tck - Project repository hosted on GitHub.
 `clone: https://github.com/jakartaee/cdi-tck.git`
 
 injection-api - Project repository hosted on GitHub.
-`clone: https://github.com/jakartaee/injection-api.git`
+`clone: https://github.com/jakartaee/inject.git`
 
 injection-spec - Project repository hosted on GitHub.
-`clone: https://github.com/jakartaee/injection-spec.git`
+`clone: https://github.com/jakartaee/inject-spec.git`
 
 injection-tck - Project repository hosted on GitHub.
-`clone: https://github.com/jakartaee/injection-tck.git`
+`clone: https://github.com/jakartaee/inject-tck.git`
 
 === Legacy CPL Licensed CDI Respositories
 cdi-tck-cpl - Project repository hosted on GitHub.

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -12,19 +12,19 @@ You can use the code from these repositories to experiment, test, build, create 
 
 === Current Respositories
 cdi - Project repository hosted on GitHub.
-`clone: https://github.com/eclipse-ee4j/cdi.git`
-
-injection-api - Project repository hosted on GitHub.
-`clone: https://github.com/eclipse-ee4j/injection-api.git`
-
-injection-spec - Project repository hosted on GitHub.
-`clone: https://github.com/eclipse-ee4j/injection-spec.git`
-
-injection-tck - Project repository hosted on GitHub.
-`clone: https://github.com/eclipse-ee4j/injection-tck.git`
+`clone: https://github.com/jakartaee/cdi.git`
 
 cdi-tck - Project repository hosted on GitHub.
-`clone: https://github.com/eclipse-ee4j/cdi-tck.git`
+`clone: https://github.com/jakartaee/cdi-tck.git`
+
+injection-api - Project repository hosted on GitHub.
+`clone: https://github.com/jakartaee/injection-api.git`
+
+injection-spec - Project repository hosted on GitHub.
+`clone: https://github.com/jakartaee/injection-spec.git`
+
+injection-tck - Project repository hosted on GitHub.
+`clone: https://github.com/jakartaee/injection-tck.git`
 
 === Legacy CPL Licensed CDI Respositories
 cdi-tck-cpl - Project repository hosted on GitHub.
@@ -39,12 +39,6 @@ Before your contribution can be accepted by the project team contributors must
 electronically sign the Eclipse Contributor Agreement (ECA).
 
 * http://www.eclipse.org/legal/ECA.php
-
-Commits that are provided by non-committers must have a Signed-off-by field in
-the footer indicating that the author is aware of the terms by which the
-contribution has been provided to the project. The non-committer must
-additionally have an Eclipse Foundation account and must have a signed Eclipse
-Contributor Agreement (ECA) on file.
 
 For more information, please see the Eclipse Committer Handbook:
 https://www.eclipse.org/projects/handbook/#resources-commit

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -29,14 +29,14 @@ The project maintains the following source code repositories:
 
 * https://github.com/jakartaee/cdi
 * https://github.com/jakartaee/cdi-tck
-* https://github.com/jakartaee/injection-api
-* https://github.com/jakartaee/injection-spec
-* https://github.com/jakartaee/injection-tck
+* https://github.com/jakartaee/inject
+* https://github.com/jakartaee/inject-spec
+* https://github.com/jakartaee/inject-tck
 
 The project also maintains the following legacy CPL licensed source code repositories:
 
-* https://github.com/eclipse-ee4j/cdi-cpl.git
-* https://github.com/eclipse-ee4j/cdi-tck-cpl.git
+* https://github.com/eclipse-ee4j/cdi-cpl
+* https://github.com/eclipse-ee4j/cdi-tck-cpl
 
 ## Third-party Content
 

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -27,7 +27,16 @@ SPDX-License-Identifier: Apache-2.0
 
 The project maintains the following source code repositories:
 
-* https://github.com/eclipse-ee4j/cdi
+* https://github.com/jakartaee/cdi
+* https://github.com/jakartaee/cdi-tck
+* https://github.com/jakartaee/injection-api
+* https://github.com/jakartaee/injection-spec
+* https://github.com/jakartaee/injection-tck
+
+The project also maintains the following legacy CPL licensed source code repositories:
+
+* https://github.com/eclipse-ee4j/cdi-cpl.git
+* https://github.com/eclipse-ee4j/cdi-tck-cpl.git
 
 ## Third-party Content
 

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,8 @@
 						<!-- files which are themselves licenses -->
 						<exclude>**/speclicense.html</exclude>
 						<exclude>**/license-*.asciidoc</exclude>
+						<!-- metadata files which aren't automatically excluded -->
+						<exclude>CODE_OF_CONDUCT.md</exclude>
 					</excludes>
 				</configuration>
 				<executions>


### PR DESCRIPTION
* Update the repository URLs in CONTRIBUTING
* List all the repositories in NOTICES
* Remove reference to `Signed-off-by` in CONTRIBUTING as it's [no longer required][no-sign-off]
* Add code of conduct file (looks like this wasn't previously required, but the handbook now says it [should be in every repo][coc-repo])

I noted a few things in these files that should be updated before I copy them over to the TCK repo.

[no-sign-off]: https://www.eclipse.org/lists/eclipse.org-committers/msg01291.html
[coc-repo]: https://www.eclipse.org/projects/handbook/#legaldoc-codeOfConduct