### PR TITLE
improve javadoc

### DIFF
--- a/api/src/main/java/jakarta/enterprise/context/BeforeDestroyed.java
+++ b/api/src/main/java/jakarta/enterprise/context/BeforeDestroyed.java
@@ -54,28 +54,28 @@ public @interface BeforeDestroyed {
      * Supports inline instantiation of the {@link BeforeDestroyed} qualifier.
      */
     public final static class Literal extends AnnotationLiteral<BeforeDestroyed> implements BeforeDestroyed {
-        /** Default RequestScoped literal */
+        /** Default BeforeDestroyed literal for the RequestScoped scope */
         public static final Literal REQUEST = of(RequestScoped.class);
-        /** Default ConversationScoped literal */
 
+        /** Default BeforeDestroyed literal for the ConversationScoped scope */
         public static final Literal CONVERSATION = of(ConversationScoped.class);
-        /** Default SessionScoped literal */
 
+        /** Default BeforeDestroyed literal for the SessionScoped scope */
         public static final Literal SESSION = of(SessionScoped.class);
-        /** Default ApplicationScoped literal */
 
+        /** Default BeforeDestroyed literal for the ApplicationScoped scope */
         public static final Literal APPLICATION = of(ApplicationScoped.class);
 
         private static final long serialVersionUID = 1L;
 
-        /** */
+        /** The scope annotation */
         private final Class<? extends Annotation> value;
 
         /**
-         * Obtain the literal of the provided scope annotation
+         * Obtain the literal for the provided scope annotation
          *
-         * @param value - the scope annotation
-         * @return a new Literal value for the provided scope annotation
+         * @param value the scope annotation
+         * @return a new literal value for the provided scope annotation
          */
         public static Literal of(Class<? extends Annotation> value) {
             return new Literal(value);

--- a/api/src/main/java/jakarta/enterprise/context/BusyConversationException.java
+++ b/api/src/main/java/jakarta/enterprise/context/BusyConversationException.java
@@ -42,35 +42,35 @@ public class BusyConversationException extends ContextException {
     private static final long serialVersionUID = -3599813072560026919L;
 
     /**
-     * default ctor
+     * Creates the exception with no detail message or cause.
      */
     public BusyConversationException() {
         super();
     }
 
     /**
-     * Create exception with given message
+     * Creates the exception with given detail message.
      *
-     * @param message - context information
+     * @param message the detail message
      */
     public BusyConversationException(String message) {
         super(message);
     }
 
     /**
-     * Create exception with given cause
+     * Creates the exception with given cause.
      *
-     * @param cause - cause of exception
+     * @param cause the cause
      */
     public BusyConversationException(Throwable cause) {
         super(cause);
     }
 
     /**
-     * Create exception with given message and cause
+     * Creates the exception with given detail message and cause.
      *
-     * @param message - context information
-     * @param cause - cause of exception
+     * @param message the detail message
+     * @param cause the cause
      */
     public BusyConversationException(String message, Throwable cause) {
         super(message, cause);

--- a/api/src/main/java/jakarta/enterprise/context/ContextException.java
+++ b/api/src/main/java/jakarta/enterprise/context/ContextException.java
@@ -27,35 +27,35 @@ public class ContextException extends RuntimeException {
     private static final long serialVersionUID = -3599813072560026919L;
 
     /**
-     * default ctor
+     * Creates the exception with no detail message or cause.
      */
     public ContextException() {
         super();
     }
 
     /**
-     * Create exception with given message and cause
+     * Creates the exception with given detail message.
      *
-     * @param message - context information
+     * @param message the detail message
      */
     public ContextException(String message) {
         super(message);
     }
 
     /**
-     * Create exception with given message and cause
+     * Creates the exception with given cause.
      *
-     * @param cause - cause of exception
+     * @param cause the cause
      */
     public ContextException(Throwable cause) {
         super(cause);
     }
 
     /**
-     * Create exception with given message and cause
+     * Creates the exception with given detail message and cause.
      *
-     * @param message - context information
-     * @param cause - cause of exception
+     * @param message the detail message
+     * @param cause the cause
      */
     public ContextException(String message, Throwable cause) {
         super(message, cause);

--- a/api/src/main/java/jakarta/enterprise/context/ContextNotActiveException.java
+++ b/api/src/main/java/jakarta/enterprise/context/ContextNotActiveException.java
@@ -33,35 +33,35 @@ public class ContextNotActiveException extends ContextException {
     private static final long serialVersionUID = -3599813072560026919L;
 
     /**
-     * Default ctor
+     * Creates the exception with no detail message or cause.
      */
     public ContextNotActiveException() {
         super();
     }
 
     /**
-     * Create exception with given message
+     * Creates the exception with given detail message.
      *
-     * @param message - context information
+     * @param message the detail message
      */
     public ContextNotActiveException(String message) {
         super(message);
     }
 
     /**
-     * Create exception with given cause
+     * Creates the exception with given cause.
      *
-     * @param cause - cause of exception
+     * @param cause the cause
      */
     public ContextNotActiveException(Throwable cause) {
         super(cause);
     }
 
     /**
-     * Create exception with given message and cause
+     * Creates the exception with given detail message and cause.
      *
-     * @param message - context information
-     * @param cause - cause of exception
+     * @param message the detail message
+     * @param cause the cause
      */
     public ContextNotActiveException(String message, Throwable cause) {
         super(message, cause);

--- a/api/src/main/java/jakarta/enterprise/context/Destroyed.java
+++ b/api/src/main/java/jakarta/enterprise/context/Destroyed.java
@@ -55,27 +55,27 @@ public @interface Destroyed {
      * @author Martin Kouba
      */
     public final static class Literal extends AnnotationLiteral<Destroyed> implements Destroyed {
-        /** Default RequestScoped literal */
+        /** Default Destroyed literal for the RequestScoped scope */
         public static final Literal REQUEST = of(RequestScoped.class);
-        /** Default ConversationScoped literal */
 
+        /** Default Destroyed literal for the ConversationScoped scope */
         public static final Literal CONVERSATION = of(ConversationScoped.class);
-        /** Default SessionScoped literal */
 
+        /** Default Destroyed literal for the SessionScoped scope */
         public static final Literal SESSION = of(SessionScoped.class);
-        /** Default ApplicationScoped literal */
 
+        /** Default Destroyed literal for the ApplicationScoped scope */
         public static final Literal APPLICATION = of(ApplicationScoped.class);
 
         private static final long serialVersionUID = 1L;
 
-        /** */
+        /** The scope annotation */
         private final Class<? extends Annotation> value;
 
         /**
          * Obtain the literal of the provided scope annotation
          *
-         * @param value - the scope annotation
+         * @param value the scope annotation
          * @return a new Literal value for the provided scope annotation
          */
         public static Literal of(Class<? extends Annotation> value) {

--- a/api/src/main/java/jakarta/enterprise/context/Initialized.java
+++ b/api/src/main/java/jakarta/enterprise/context/Initialized.java
@@ -55,27 +55,27 @@ public @interface Initialized {
      * @author Martin Kouba
      */
     public final static class Literal extends AnnotationLiteral<Initialized> implements Initialized {
-        /** Default RequestScoped literal */
+        /** Default Initialized literal for the RequestScoped scope */
         public static final Literal REQUEST = of(RequestScoped.class);
-        /** Default ConversationScoped literal */
 
+        /** Default Initialized literal for the ConversationScoped scope */
         public static final Literal CONVERSATION = of(ConversationScoped.class);
-        /** Default SessionScoped literal */
 
+        /** Default Initialized literal for the SessionScoped scope */
         public static final Literal SESSION = of(SessionScoped.class);
-        /** Default ApplicationScoped literal */
 
+        /** Default Initialized literal for the ApplicationScoped scope */
         public static final Literal APPLICATION = of(ApplicationScoped.class);
 
         private static final long serialVersionUID = 1L;
 
-        /** */
+        /** The scope annotation */
         private final Class<? extends Annotation> value;
 
         /**
          * Obtain the literal of the provided scope annotation
          *
-         * @param value - the scope annotation
+         * @param value the scope annotation
          * @return a new Literal value for the provided scope annotation
          */
         public static Literal of(Class<? extends Annotation> value) {

--- a/api/src/main/java/jakarta/enterprise/context/NonexistentConversationException.java
+++ b/api/src/main/java/jakarta/enterprise/context/NonexistentConversationException.java
@@ -39,35 +39,35 @@ public class NonexistentConversationException extends ContextException {
     private static final long serialVersionUID = -3599813072560026919L;
 
     /**
-     * Default ctor
+     * Creates the exception with no detail message or cause.
      */
     public NonexistentConversationException() {
         super();
     }
 
     /**
-     * Create exception with given message
+     * Creates the exception with given detail message.
      *
-     * @param message - context information
+     * @param message the detail message
      */
     public NonexistentConversationException(String message) {
         super(message);
     }
 
     /**
-     * Create exception with given cause
+     * Creates the exception with given cause.
      *
-     * @param cause - cause of exception
+     * @param cause the cause
      */
     public NonexistentConversationException(Throwable cause) {
         super(cause);
     }
 
     /**
-     * Create exception with given message and cause
+     * Creates the exception with given detail message and cause.
      *
-     * @param message - context information
-     * @param cause - cause of exception
+     * @param message the detail message
+     * @param cause the cause
      */
     public NonexistentConversationException(String message, Throwable cause) {
         super(message, cause);

--- a/api/src/main/java/jakarta/enterprise/context/RequestScoped.java
+++ b/api/src/main/java/jakarta/enterprise/context/RequestScoped.java
@@ -95,7 +95,7 @@ public @interface RequestScoped {
      * @since 2.0
      */
     public final static class Literal extends AnnotationLiteral<RequestScoped> implements RequestScoped {
-        /** Default RequestScope literal */
+        /** Default RequestScoped literal */
         public static final Literal INSTANCE = new Literal();
 
         private static final long serialVersionUID = 1L;

--- a/api/src/main/java/jakarta/enterprise/event/NotificationOptions.java
+++ b/api/src/main/java/jakarta/enterprise/event/NotificationOptions.java
@@ -75,7 +75,7 @@ public interface NotificationOptions {
         /**
          * Set the notification executor
          *
-         * @param executor - {@linkplain Executor}
+         * @param executor the {@linkplain Executor}
          * @return this
          */
         Builder setExecutor(Executor executor);
@@ -83,8 +83,8 @@ public interface NotificationOptions {
         /**
          * Set an option value
          *
-         * @param optionName - name
-         * @param optionValue - value
+         * @param optionName option name
+         * @param optionValue option value
          * @return this
          */
         Builder set(String optionName, Object optionValue);

--- a/api/src/main/java/jakarta/enterprise/event/ObserverException.java
+++ b/api/src/main/java/jakarta/enterprise/event/ObserverException.java
@@ -27,35 +27,35 @@ public class ObserverException extends RuntimeException {
     private static final long serialVersionUID = -801836224808304381L;
 
     /**
-     * Default ctor
+     * Creates the exception with no detail message or cause.
      */
     public ObserverException() {
 
     }
 
     /**
-     * Create exception with given message
+     * Creates the exception with given detail message.
      *
-     * @param message - context information
+     * @param message the detail message
      */
     public ObserverException(String message) {
         super(message);
     }
 
     /**
-     * Create exception with given cause
+     * Creates the exception with given cause.
      *
-     * @param cause - cause of exception
+     * @param cause the cause
      */
     public ObserverException(Throwable cause) {
         super(cause);
     }
 
     /**
-     * Create exception with given message and cause
+     * Creates the exception with given detail message and cause.
      *
-     * @param message - context information
-     * @param cause - cause of exception
+     * @param message the detail message
+     * @param cause the cause
      */
     public ObserverException(String message, Throwable cause) {
         super(message, cause);

--- a/api/src/main/java/jakarta/enterprise/inject/AmbiguousResolutionException.java
+++ b/api/src/main/java/jakarta/enterprise/inject/AmbiguousResolutionException.java
@@ -27,37 +27,37 @@ public class AmbiguousResolutionException extends ResolutionException {
     private static final long serialVersionUID = -2132733164534544788L;
 
     /**
-     * default ctor
+     * Creates the exception with no detail message or cause.
      */
     public AmbiguousResolutionException() {
     }
 
     /**
-     * Create exception with given message and cause
+     * Creates the exception with given detail message and cause.
      *
-     * @param message - context information
-     * @param throwable - cause of exception
+     * @param message the detail message
+     * @param cause the cause
      */
-    public AmbiguousResolutionException(String message, Throwable throwable) {
-        super(message, throwable);
+    public AmbiguousResolutionException(String message, Throwable cause) {
+        super(message, cause);
     }
 
     /**
-     * Create exception with given message
+     * Creates the exception with given detail message.
      *
-     * @param message - context information
+     * @param message the detail message
      */
     public AmbiguousResolutionException(String message) {
         super(message);
     }
 
     /**
-     * Create exception with given cause
+     * Creates the exception with given cause.
      *
-     * @param throwable - cause of exception
+     * @param cause the cause
      */
-    public AmbiguousResolutionException(Throwable throwable) {
-        super(throwable);
+    public AmbiguousResolutionException(Throwable cause) {
+        super(cause);
     }
 
 }

--- a/api/src/main/java/jakarta/enterprise/inject/CreationException.java
+++ b/api/src/main/java/jakarta/enterprise/inject/CreationException.java
@@ -27,35 +27,35 @@ public class CreationException extends InjectionException {
     private static final long serialVersionUID = 1002854668862145298L;
 
     /**
-     * Default ctor
+     * Creates the exception with no detail message or cause.
      */
     public CreationException() {
 
     }
 
     /**
-     * Create exception with given message
+     * Creates the exception with given detail message.
      *
-     * @param message - context information
+     * @param message the detail message
      */
     public CreationException(String message) {
         super(message);
     }
 
     /**
-     * Create exception with given cause
+     * Creates the exception with given cause.
      *
-     * @param cause - cause of exception
+     * @param cause the cause
      */
     public CreationException(Throwable cause) {
         super(cause);
     }
 
     /**
-     * Create exception with given message and cause
+     * Creates the exception with given detail message and cause.
      *
-     * @param message - context information
-     * @param cause - cause of exception
+     * @param message the detail message
+     * @param cause the cause
      */
     public CreationException(String message, Throwable cause) {
         super(message, cause);

--- a/api/src/main/java/jakarta/enterprise/inject/IllegalProductException.java
+++ b/api/src/main/java/jakarta/enterprise/inject/IllegalProductException.java
@@ -26,35 +26,35 @@ public class IllegalProductException extends InjectionException {
     private static final long serialVersionUID = -6280627846071966243L;
 
     /**
-     * Default ctor
+     * Creates the exception with no detail message or cause.
      */
     public IllegalProductException() {
         super();
     }
 
     /**
-     * Create exception with given message and cause
+     * Creates the exception with given detail message and cause.
      *
-     * @param message - context information
-     * @param cause - cause of exception
+     * @param message the detail message
+     * @param cause the cause
      */
     public IllegalProductException(String message, Throwable cause) {
         super(message, cause);
     }
 
     /**
-     * Create exception with given message
+     * Creates the exception with given detail message.
      *
-     * @param message - context information
+     * @param message the detail message
      */
     public IllegalProductException(String message) {
         super(message);
     }
 
     /**
-     * Create exception with given cause
+     * Creates the exception with given cause.
      *
-     * @param cause - cause of exception
+     * @param cause the cause
      */
     public IllegalProductException(Throwable cause) {
         super(cause);

--- a/api/src/main/java/jakarta/enterprise/inject/InjectionException.java
+++ b/api/src/main/java/jakarta/enterprise/inject/InjectionException.java
@@ -24,34 +24,34 @@ public class InjectionException extends RuntimeException {
     private static final long serialVersionUID = -2132733164534544788L;
 
     /**
-     * Default ctor
+     * Creates the exception with no detail message or cause.
      */
     public InjectionException() {
     }
 
     /**
-     * Create exception with given message and cause
+     * Creates the exception with given detail message and cause.
      *
-     * @param message - context information
-     * @param cause - cause of exception
+     * @param message the detail message
+     * @param cause the cause
      */
     public InjectionException(String message, Throwable cause) {
         super(message, cause);
     }
 
     /**
-     * Create exception with given message
+     * Creates the exception with given detail message.
      *
-     * @param message - context information
+     * @param message the detail message
      */
     public InjectionException(String message) {
         super(message);
     }
 
     /**
-     * Create exception with given cause
+     * Creates the exception with given cause.
      *
-     * @param cause - cause of exception
+     * @param cause the cause
      */
     public InjectionException(Throwable cause) {
         super(cause);

--- a/api/src/main/java/jakarta/enterprise/inject/ResolutionException.java
+++ b/api/src/main/java/jakarta/enterprise/inject/ResolutionException.java
@@ -23,35 +23,35 @@ public class ResolutionException extends InjectionException {
     private static final long serialVersionUID = -6280627846071966243L;
 
     /**
-     * Default ctor
+     * Creates the exception with no detail message or cause.
      */
     public ResolutionException() {
         super();
     }
 
     /**
-     * Create exception with given message and cause
+     * Creates the exception with given detail message and cause.
      *
-     * @param message - context information
-     * @param cause - cause of exception
+     * @param message the detail message
+     * @param cause the cause
      */
     public ResolutionException(String message, Throwable cause) {
         super(message, cause);
     }
 
     /**
-     * Create exception with given message
+     * Creates the exception with given detail message.
      *
-     * @param message - context information
+     * @param message the detail message
      */
     public ResolutionException(String message) {
         super(message);
     }
 
     /**
-     * Create exception with given cause
+     * Creates the exception with given cause.
      *
-     * @param cause - cause of exception
+     * @param cause the cause
      */
     public ResolutionException(Throwable cause) {
         super(cause);

--- a/api/src/main/java/jakarta/enterprise/inject/Typed.java
+++ b/api/src/main/java/jakarta/enterprise/inject/Typed.java
@@ -54,8 +54,8 @@ import jakarta.enterprise.util.AnnotationLiteral;
 public @interface Typed {
     /**
      * <p>
-     * Selects the bean types of the bean. Every class must correspond to a type in the unrestricted set of bean types of a
-     * bean.
+     * Selects the bean types of the bean. Every class must correspond to a type in the unrestricted set of bean types
+     * of a bean.
      * </p>
      *
      * @return the classes corresponding to the bean types of the bean
@@ -74,13 +74,13 @@ public @interface Typed {
 
         private static final long serialVersionUID = 1L;
 
-        /** */
+        /** The classes corresponding to the bean types of the bean */
         private final Class<?>[] value;
 
         /**
-         * Obtain the Type literal of the provided bean classes
+         * Obtain the Typed literal for the provided bean types
          *
-         * @param value - the classes corresponding to the bean types of the bean
+         * @param value the classes corresponding to the bean types of the bean
          * @return a new Literal value for the provided classes
          */
         public static Literal of(Class<?>[] value) {

--- a/api/src/main/java/jakarta/enterprise/inject/UnproxyableResolutionException.java
+++ b/api/src/main/java/jakarta/enterprise/inject/UnproxyableResolutionException.java
@@ -28,35 +28,35 @@ public class UnproxyableResolutionException extends ResolutionException {
     private static final long serialVersionUID = 1667539354548135465L;
 
     /**
-     * Default ctor
+     * Creates the exception with no detail message or cause.
      */
     public UnproxyableResolutionException() {
         super();
     }
 
     /**
-     * Create exception with given message and cause
+     * Creates the exception with given detail message and cause.
      *
-     * @param message - context information
-     * @param cause - cause of exception
+     * @param message the detail message
+     * @param cause the cause
      */
     public UnproxyableResolutionException(String message, Throwable cause) {
         super(message, cause);
     }
 
     /**
-     * Create exception with given message
+     * Creates the exception with given detail message.
      *
-     * @param message - context information
+     * @param message the detail message
      */
     public UnproxyableResolutionException(String message) {
         super(message);
     }
 
     /**
-     * Create exception with given cause
+     * Creates the exception with given cause.
      *
-     * @param cause - cause of exception
+     * @param cause the cause
      */
     public UnproxyableResolutionException(Throwable cause) {
         super(cause);

--- a/api/src/main/java/jakarta/enterprise/inject/UnsatisfiedResolutionException.java
+++ b/api/src/main/java/jakarta/enterprise/inject/UnsatisfiedResolutionException.java
@@ -27,35 +27,35 @@ public class UnsatisfiedResolutionException extends ResolutionException {
     private static final long serialVersionUID = 5350603312442756709L;
 
     /**
-     * Default ctor
+     * Creates the exception with no detail message or cause.
      */
     public UnsatisfiedResolutionException() {
         super();
     }
 
     /**
-     * Create exception with given message and cause
+     * Creates the exception with given detail message and cause.
      *
-     * @param message - context information
-     * @param cause - cause of exception
+     * @param message the detail message
+     * @param cause the cause
      */
     public UnsatisfiedResolutionException(String message, Throwable cause) {
         super(message, cause);
     }
 
     /**
-     * Create exception with given message
+     * Creates the exception with given detail message.
      *
-     * @param message - context information
+     * @param message the detail message
      */
     public UnsatisfiedResolutionException(String message) {
         super(message);
     }
 
     /**
-     * Create exception with given cause
+     * Creates the exception with given cause.
      *
-     * @param cause - cause of exception
+     * @param cause the cause
      */
     public UnsatisfiedResolutionException(Throwable cause) {
         super(cause);

--- a/api/src/main/java/jakarta/enterprise/inject/literal/NamedLiteral.java
+++ b/api/src/main/java/jakarta/enterprise/inject/literal/NamedLiteral.java
@@ -24,18 +24,18 @@ import jakarta.inject.Named;
  * @since 2.0
  */
 public final class NamedLiteral extends AnnotationLiteral<Named> implements Named {
-    /** Default NamedLiteral */
+    /** Default Named literal */
     public static final Named INSTANCE = of("");
 
     private static final long serialVersionUID = 1L;
 
-    /** */
+    /** The name */
     private final String value;
 
     /**
      * Create a new NamedLiteral for the given name value
      *
-     * @param value - name
+     * @param value the name
      * @return new NamedLiteral
      */
     public static NamedLiteral of(String value) {

--- a/api/src/main/java/jakarta/enterprise/inject/literal/QualifierLiteral.java
+++ b/api/src/main/java/jakarta/enterprise/inject/literal/QualifierLiteral.java
@@ -23,7 +23,7 @@ import jakarta.inject.Qualifier;
  * @since 2.0
  */
 public final class QualifierLiteral extends AnnotationLiteral<Qualifier> implements Qualifier {
-    /** Default QualifierLiteral instance */
+    /** Default Qualifier literal */
     public static final QualifierLiteral INSTANCE = new QualifierLiteral();
 
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/jakarta/enterprise/inject/literal/SingletonLiteral.java
+++ b/api/src/main/java/jakarta/enterprise/inject/literal/SingletonLiteral.java
@@ -23,7 +23,7 @@ import jakarta.inject.Singleton;
  * @since 2.0
  */
 public final class SingletonLiteral extends AnnotationLiteral<Singleton> implements Singleton {
-    /** Default SingletonLiteral instance */
+    /** Default Singleton literal */
     public static final SingletonLiteral INSTANCE = new SingletonLiteral();
 
     private static final long serialVersionUID = 1L;

--- a/api/src/main/java/jakarta/enterprise/inject/spi/CDI.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/CDI.java
@@ -44,7 +44,7 @@ public abstract class CDI<T> implements Instance<T> {
     private static volatile boolean providerSetManually = false;
     /** The set of discovered CDIProviders */
     protected static volatile Set<CDIProvider> discoveredProviders = null;
-    /** {@link CDIProvider} set by user or retrieved by serviceloader */
+    /** {@link CDIProvider} set by user or retrieved by service loader */
     protected static volatile CDIProvider configuredProvider = null;
 
     /**

--- a/api/src/main/java/jakarta/enterprise/inject/spi/DefinitionException.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/DefinitionException.java
@@ -42,28 +42,28 @@ public class DefinitionException extends RuntimeException {
     private static final long serialVersionUID = -2699170549782567339L;
 
     /**
-     * Create exception with given message and cause
+     * Creates the exception with given detail message and cause.
      *
-     * @param message - context information
-     * @param cause - cause of exception
+     * @param message the detail message
+     * @param cause the cause
      */
     public DefinitionException(String message, Throwable cause) {
         super(message, cause);
     }
 
     /**
-     * Create exception with given message
+     * Creates the exception with given detail message.
      *
-     * @param message - context information
+     * @param message the detail message
      */
     public DefinitionException(String message) {
         super(message);
     }
 
     /**
-     * Create exception with given cause
+     * Creates the exception with given cause.
      *
-     * @param cause - cause of exception
+     * @param cause the cause
      */
     public DefinitionException(Throwable cause) {
         super(cause);

--- a/api/src/main/java/jakarta/enterprise/inject/spi/DeploymentException.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/DeploymentException.java
@@ -42,28 +42,28 @@ public class DeploymentException extends RuntimeException {
     private static final long serialVersionUID = 2604707587772339984L;
 
     /**
-     * Create exception with given message and cause
+     * Creates the exception with given detail message and cause.
      *
-     * @param message - context information
-     * @param cause - cause of exception
+     * @param message the detail message
+     * @param cause the cause
      */
     public DeploymentException(String message, Throwable cause) {
         super(message, cause);
     }
 
     /**
-     * Create exception with given message
+     * Creates the exception with given detail message.
      *
-     * @param message - context information
+     * @param message the detail message
      */
     public DeploymentException(String message) {
         super(message);
     }
 
     /**
-     * Create exception with given cause
+     * Creates the exception with given cause.
      *
-     * @param cause - cause of exception
+     * @param cause the cause
      */
     public DeploymentException(Throwable cause) {
         super(cause);

--- a/api/src/main/java/jakarta/enterprise/inject/spi/ObserverMethod.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/ObserverMethod.java
@@ -40,7 +40,7 @@ import jakarta.enterprise.event.TransactionPhase;
  * @param <T> the event type
  */
 public interface ObserverMethod<T> extends Prioritized {
-    /** The default observer notification priority */
+    /** The default observer priority */
     public static final int DEFAULT_PRIORITY = jakarta.interceptor.Interceptor.Priority.APPLICATION + 500;
 
     /**

--- a/api/src/main/java/jakarta/enterprise/inject/spi/WithAnnotations.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/WithAnnotations.java
@@ -45,9 +45,10 @@ import java.lang.annotation.Target;
 @Target(PARAMETER)
 public @interface WithAnnotations {
     /**
-     * Event annotation types to observe
+     * The annotation types that must be present on the {@link AnnotatedType}
+     * for the {@code ProcessAnnotatedType} observer to be notified.
      *
-     * @return Event annotation types to observe
+     * @return required annotation types
      */
     Class<? extends Annotation>[] value();
 

--- a/api/src/main/java/jakarta/enterprise/util/AnnotationLiteral.java
+++ b/api/src/main/java/jakarta/enterprise/util/AnnotationLiteral.java
@@ -72,7 +72,7 @@ public abstract class AnnotationLiteral<T extends Annotation> implements Annotat
     private transient Integer cachedHashCode;
 
     /**
-     * Default ctor
+     * The literal constructor, only for subclasses.
      */
     protected AnnotationLiteral() {
     }

--- a/api/src/main/java/jakarta/enterprise/util/TypeLiteral.java
+++ b/api/src/main/java/jakarta/enterprise/util/TypeLiteral.java
@@ -53,7 +53,7 @@ public abstract class TypeLiteral<T> implements Serializable {
     private transient Type actualType;
 
     /**
-     * Default ctor
+     * The literal constructor, only for subclasses.
      */
     protected TypeLiteral() {
     }

--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -12,7 +12,7 @@
  * limitations under the License.
  */
 /**
- * The CDI exported package, dependency information and services
+ * The {@code jakarta.cdi} module; defines the CDI API exported packages, dependencies and services.
  */
 module jakarta.cdi {
     exports jakarta.decorator;

--- a/el/src/main/java/jakarta/enterprise/inject/spi/el/ELAwareBeanManager.java
+++ b/el/src/main/java/jakarta/enterprise/inject/spi/el/ELAwareBeanManager.java
@@ -19,8 +19,8 @@ import jakarta.enterprise.context.Dependent;
 import jakarta.enterprise.inject.spi.BeanManager;
 
 /**
- * A {@link BeanManager} that allows integrators to obtain Unified EL objects
- * that are integrated with the CDI container as described in the CDI specification.
+ * A {@link BeanManager} that allows integrators to obtain Unified EL objects that are
+ * integrated with the CDI container as described in the Jakarta EE Platform specification.
  *
  * @since 4.1
  */

--- a/el/src/main/java/module-info.java
+++ b/el/src/main/java/module-info.java
@@ -11,6 +11,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * The {@code jakarta.cdi.el} module; defines the CDI EL API exported packages and dependencies.
+ */
 module jakarta.cdi.el {
     exports jakarta.enterprise.inject.spi.el;
 

--- a/lang-model/src/main/java/jakarta/enterprise/lang/model/declarations/DeclarationInfo.java
+++ b/lang-model/src/main/java/jakarta/enterprise/lang/model/declarations/DeclarationInfo.java
@@ -26,6 +26,7 @@ import jakarta.enterprise.lang.model.types.Type;
  * <li>{@linkplain FieldInfo fields}</li>
  * <li>{@linkplain MethodInfo methods}, including constructors</li>
  * <li>{@linkplain ParameterInfo method parameters}, including constructor parameters</li>
+ * <li>{@linkplain RecordComponentInfo record components}</li>
  * </ul>
  *
  * @since 4.0
@@ -51,12 +52,33 @@ public interface DeclarationInfo extends AnnotationTarget {
         throw new IllegalStateException("Not a type");
     }
 
+    /**
+     * The declaration kind: package, class, method, parameter, field, record component.
+     */
     enum Kind {
+        /**
+         * Package
+         */
         PACKAGE,
+        /**
+         * Class, interface, enum, annotation, or record
+         */
         CLASS,
+        /**
+         * Method or constructor
+         */
         METHOD,
+        /**
+         * Method parameter or constructor parameter
+         */
         PARAMETER,
+        /**
+         * Field
+         */
         FIELD,
+        /**
+         * Record component
+         */
         RECORD_COMPONENT,
     }
 

--- a/lang-model/src/main/java/jakarta/enterprise/lang/model/types/PrimitiveType.java
+++ b/lang-model/src/main/java/jakarta/enterprise/lang/model/types/PrimitiveType.java
@@ -30,14 +30,41 @@ package jakarta.enterprise.lang.model.types;
  * @since 4.0
  */
 public interface PrimitiveType extends Type {
+    /**
+     * The primitive type kind: boolean, byte, short, int, long, float, double, char
+     */
     enum PrimitiveKind {
+        /**
+         * The {@code boolean} primitive type
+         */
         BOOLEAN,
+        /**
+         * The {@code byte} primitive type
+         */
         BYTE,
+        /**
+         * The {@code short} primitive type
+         */
         SHORT,
+        /**
+         * The {@code int} primitive type
+         */
         INT,
+        /**
+         * The {@code long} primitive type
+         */
         LONG,
+        /**
+         * The {@code float} primitive type
+         */
         FLOAT,
+        /**
+         * The {@code double} primitive type
+         */
         DOUBLE,
+        /**
+         * The {@code char} primitive type
+         */
         CHAR,
     }
 

--- a/lang-model/src/main/java/jakarta/enterprise/lang/model/types/Type.java
+++ b/lang-model/src/main/java/jakarta/enterprise/lang/model/types/Type.java
@@ -68,22 +68,28 @@ public interface Type extends AnnotationTarget {
         return this;
     }
 
+    /**
+     * The type kind: void, primitive, class, array, parameterized type, type variable, wildcard type
+     */
     enum Kind {
-        /** E.g. when method returns {@code void}. */
+        /** The void pseudo-type, e.g. when method returns {@code void}. */
         VOID,
-        /** E.g. when method returns {@code int}. */
+        /** A primitive type, e.g. when method returns {@code int}. */
         PRIMITIVE,
-        /** E.g. when method returns {@code String}. */
+        /** A class type, e.g. when method returns {@code String}. */
         CLASS,
-        /** E.g. when method returns {@code int[]} or {@code String[][]}. */
+        /** An array type, e.g. when method returns {@code int[]} or {@code String[][]}. */
         ARRAY,
-        /** E.g. when method returns {@code List<String>}. */
+        /** A parameterized type, e.g. when method returns {@code List<String>}. */
         PARAMETERIZED_TYPE,
-        /** E.g. when method returns {@code T} and {@code T} is a type parameter of the declaring class. */
+        /**
+         * A type variable, e.g. when method returns {@code T} and {@code T} is a type parameter
+         * of the declaring class.
+         */
         TYPE_VARIABLE,
         /**
-         * E.g. when method returns {@code List<? extends Number>}. The kind of such type is {@code PARAMETERIZED_TYPE},
-         * but the first (and only) type argument is a {@code WILDCARD_TYPE}.
+         * A wildcard type, e.g. when method returns {@code List<? extends Number>}. The kind of such type
+         * is {@code PARAMETERIZED_TYPE}, but the first (and only) type argument is a {@code WILDCARD_TYPE}.
          */
         WILDCARD_TYPE,
     }

--- a/lang-model/src/main/java/module-info.java
+++ b/lang-model/src/main/java/module-info.java
@@ -11,6 +11,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * The {@code jakarta.cdi.lang.model} module; defines the CDI Language Model API exported packages
+ */
 module jakarta.cdi.lang.model {
     exports jakarta.enterprise.lang.model;
     exports jakarta.enterprise.lang.model.declarations;


### PR DESCRIPTION
The 1st commit is my review of #775. The 2nd commit avoids javadoc warnings in the `el` module. The 3rd commit avoids javadoc warnings in the `lang-model` module.