### PR TITLE
Allow registering BCE in CDI SE without discovery

### DIFF
--- a/api/src/main/java/jakarta/enterprise/inject/se/SeContainerInitializer.java
+++ b/api/src/main/java/jakarta/enterprise/inject/se/SeContainerInitializer.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
 
+import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;
 import jakarta.enterprise.inject.spi.Extension;
 
 /**
@@ -190,21 +191,31 @@ public abstract class SeContainerInitializer {
     public abstract SeContainerInitializer addPackages(boolean scanRecursively, Package... packages);
 
     /**
-     * Add extensions to the set of extensions.
+     * Add portable extensions to the set of extensions.
      *
-     * @param extensions extensions to use in the container
+     * @param extensions portable extensions to use in the container
      * @return self
      */
     public abstract SeContainerInitializer addExtensions(Extension... extensions);
 
     /**
-     * Add extensions to the set of extensions.
+     * Add portable extensions to the set of extensions.
      *
-     * @param extensions extensions class to use in the container
+     * @param extensions portable extension classes to use in the container
      * @return self
      */
     @SuppressWarnings("unchecked")
     public abstract SeContainerInitializer addExtensions(Class<? extends Extension>... extensions);
+
+    /**
+     * Add build compatible extensions to the set of extensions.
+     *
+     * @param extensions build compatible extension classes to use in the container
+     * @return self
+     */
+    @SuppressWarnings("unchecked")
+    public abstract SeContainerInitializer addBuildCompatibleExtensions(
+            Class<? extends BuildCompatibleExtension>... extensions);
 
     /**
      * Add interceptor classes to the list of enabled interceptors for the synthetic bean archive.

--- a/api/src/test/java/org/jboss/cdi/api/test/se/DummySeContainerInitializer.java
+++ b/api/src/test/java/org/jboss/cdi/api/test/se/DummySeContainerInitializer.java
@@ -17,6 +17,7 @@ package org.jboss.cdi.api.test.se;
 import java.lang.annotation.Annotation;
 import java.util.Map;
 
+import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;
 import jakarta.enterprise.inject.se.SeContainer;
 import jakarta.enterprise.inject.se.SeContainerInitializer;
 import jakarta.enterprise.inject.spi.Extension;
@@ -61,6 +62,11 @@ public class DummySeContainerInitializer extends SeContainerInitializer {
     @SafeVarargs
     @Override
     public final SeContainerInitializer addExtensions(Class<? extends Extension>... extensions) {
+        return null;
+    }
+
+    @Override
+    public SeContainerInitializer addBuildCompatibleExtensions(Class<? extends BuildCompatibleExtension>... extensions) {
         return null;
     }
 

--- a/api/src/test/java/org/jboss/cdi/api/test/se/DummySeContainerInitializer2.java
+++ b/api/src/test/java/org/jboss/cdi/api/test/se/DummySeContainerInitializer2.java
@@ -17,6 +17,7 @@ package org.jboss.cdi.api.test.se;
 import java.lang.annotation.Annotation;
 import java.util.Map;
 
+import jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension;
 import jakarta.enterprise.inject.se.SeContainer;
 import jakarta.enterprise.inject.se.SeContainerInitializer;
 import jakarta.enterprise.inject.spi.Extension;
@@ -61,6 +62,11 @@ public class DummySeContainerInitializer2 extends SeContainerInitializer {
     @SafeVarargs
     @Override
     public final SeContainerInitializer addExtensions(Class<? extends Extension>... extensions) {
+        return null;
+    }
+
+    @Override
+    public SeContainerInitializer addBuildCompatibleExtensions(Class<? extends BuildCompatibleExtension>... extensions) {
         return null;
     }
 

--- a/spec/src/main/asciidoc/javase/bootstrap_se.asciidoc
+++ b/spec/src/main/asciidoc/javase/bootstrap_se.asciidoc
@@ -46,6 +46,7 @@ public abstract class SeContainerInitializer {
     public SeContainerInitializer addPackages(boolean scanRecursively, Package... packages);
     public SeContainerInitializer addExtensions(Extension... extensions);
     public SeContainerInitializer addExtensions(Class<? extends Extension>... extensions);
+    public SeContainerInitializer addBuildCompatibleExtensions(Class<? extends BuildCompatibleExtension>... extensions);
     public SeContainerInitializer enableInterceptors(Class<?>... interceptorClasses);
     public SeContainerInitializer enableDecorators(Class<?>... decoratorClasses);
     public SeContainerInitializer selectAlternatives(Class<?>... alternativeClasses);
@@ -65,7 +66,8 @@ Each call returns a new instance of `SeContainerInitializer`. This method throws
 * `addBeanClasses()` adds classes to the the synthetic bean archive
 * `addPackages()` adds packages content to the synthetic bean archive.
 There are other versions of this method, which enables user to add a package according to class or classes it contains and also to add packages recursively.
-* `addExtensions()` adds the provided extensions (class or instance) to the synthetic bean archive.
+* `addExtensions()` adds the provided portable extensions (class or instance) to the synthetic bean archive.
+* `addBuildCompatibleExtensions()` adds the provided build compatible extensions (classes) to the synthetic bean archive.
 * `enableInterceptors()` adds interceptor classes to the list of enabled interceptors for the synthetic bean archive.
 * `enableDecorators()` adds decorator classes to the list of enabled decorators for the synthetic bean archive.
 * `selectAlternatives()` adds alternatives classes to the list of selected alternatives for the synthetic bean archive.


### PR DESCRIPTION
Fixes #813 

Adds a new method to `SeContainerInitializer` which allows users to register build compatible extensions (BCE) without the need for discovery.

I am aware the `SeContainerInitializer` has [two variants of the `add` method for portable extensions (PE)](https://github.com/jakartaee/cdi/blob/4.1.0/api/src/main/java/jakarta/enterprise/inject/se/SeContainerInitializer.java#L192-L207), one of which allows you to pass in pre-initialized PE.
I intentionally skipped that for BCE as those were designed with stricter environments in mind. However, if there is need/want for this we can add it as well.