### PR TITLE
Add slightly more details to the `Invoker` javadoc

### DIFF
--- a/api/src/main/java/jakarta/enterprise/invoke/Invoker.java
+++ b/api/src/main/java/jakarta/enterprise/invoke/Invoker.java
@@ -43,19 +43,24 @@ package jakarta.enterprise.invoke;
  * @param <R> return type of the target method
  * @since 4.1
  * @see #invoke(Object, Object[])
+ * @see InvokerBuilder
  */
 public interface Invoker<T, R> {
     /**
      * Invokes the target method on the given {@code instance} of the target bean, passing
-     * given {@code arguments}. If the target method returns normally, this method returns
-     * its return value, unless the target method is declared {@code void}, in which case
-     * this method returns {@code null}. If the target method throws an exception, it is
-     * rethrown directly.
+     * given {@code arguments}. If the target method is {@code static}, the {@code instance}
+     * is ignored and should be {@code null} by convention. If the target method returns normally,
+     * this method returns its return value, unless the target method is declared {@code void},
+     * in which case this method returns {@code null}. If the target method throws an exception,
+     * it is rethrown directly.
      *
      * @param instance the instance of the target bean on which the target method is to be invoked;
-     *        may only be {@code null} if the target method is {@code static}
+     *        may only be {@code null} if the target method is {@code static} or if instance lookup
+     *        was {@linkplain InvokerBuilder#withInstanceLookup() configured}
      * @param arguments arguments to be passed to the target method; may only be {@code null}
-     *        if the target method declares no parameter
+     *        if the target method declares no parameter; if the target method declares at least
+     *        one parameter, this array must have at least as many elements as the number of parameters
+     *        of the target method
      * @return return value of the target method, or {@code null} if the target method
      *         is declared {@code void}
      * @throws RuntimeException when {@code instance} or {@code arguments} are incorrect

--- a/api/src/main/java/jakarta/enterprise/invoke/InvokerBuilder.java
+++ b/api/src/main/java/jakarta/enterprise/invoke/InvokerBuilder.java
@@ -59,6 +59,9 @@ package jakarta.enterprise.invoke;
 public interface InvokerBuilder<T> {
     /**
      * Enables lookup of the target bean instance.
+     * <p>
+     * When enabled, the {@code instance} passed to {@link Invoker#invoke(Object, Object[]) Invoker.invoke()}
+     * is ignored and the target instance is looked up from the CDI container instead.
      *
      * @return this builder
      */
@@ -66,6 +69,10 @@ public interface InvokerBuilder<T> {
 
     /**
      * Enables lookup of the argument on given {@code position}.
+     * <p>
+     * When enabled, the corresponding element of the {@code arguments} array passed
+     * to {@link Invoker#invoke(Object, Object[]) Invoker.invoke()} is ignored and the argument
+     * is looked up from the CDI container instead.
      *
      * @param position zero-based position of the target method parameter for which lookup should be enabled
      * @return this builder


### PR DESCRIPTION
The specification text is detailed enough, but we figured that adding slightly more text to the `Invoker` (and `InvokerBuilder`) javadoc can be helpful.