### PR TITLE
use the term "bean name" instead of "EL name" in the API

### DIFF
--- a/api/src/main/java/jakarta/enterprise/context/Dependent.java
+++ b/api/src/main/java/jakarta/enterprise/context/Dependent.java
@@ -45,9 +45,9 @@ import jakarta.inject.Scope;
  * <li>No injected instance of the bean is ever shared between multiple injection points.</li>
  * <li>Any instance of the bean injected into an object that is being created by the container is bound to the lifecycle of the
  * newly created object.</li>
- * <li>When a Unified EL expression in a JSF or JSP page that refers to the bean by its EL name is evaluated, at most one
- * instance of the bean is instantiated. This instance exists to service just a single evaluation of the EL expression. It is
- * reused if the bean EL name appears multiple times in the EL expression, but is never reused when the EL expression is
+ * <li>When a Unified EL expression that refers to the bean by its bean name is evaluated, at most one instance
+ * of the bean is instantiated. This instance exists to service just a single evaluation of the EL expression. It is
+ * reused if the bean name appears multiple times in the EL expression, but is never reused when the EL expression is
  * evaluated again, or when another EL expression is evaluated.</li>
  * <li>Any instance of the bean that receives a producer method, producer field, disposer method or observer method invocation
  * exists to service that invocation only.</li>

--- a/api/src/main/java/jakarta/enterprise/inject/Stereotype.java
+++ b/api/src/main/java/jakarta/enterprise/inject/Stereotype.java
@@ -81,7 +81,7 @@ import java.lang.annotation.Target;
  * </p>
  *
  * <ul>
- * <li>all beans with the stereotype have defaulted bean EL names, or that</li>
+ * <li>all beans with the stereotype have defaulted bean names, or that</li>
  * <li>all beans with the stereotype are alternatives, or that</li>
  * <li>all beans with the stereotype have predefined {@code @Priority}.</li>
  * </ul>

--- a/api/src/main/java/jakarta/enterprise/inject/spi/BeanAttributes.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/BeanAttributes.java
@@ -52,9 +52,10 @@ public interface BeanAttributes<T> {
     public Class<? extends Annotation> getScope();
 
     /**
-     * Obtains the {@linkplain jakarta.enterprise.inject EL name} of a bean, if it has one.
+     * Obtains the bean name of the bean, if it has one.
+     * If this bean has no name, returns {@code null}.
      *
-     * @return the {@linkplain jakarta.enterprise.inject EL name}
+     * @return the bean name
      */
     public String getName();
 

--- a/api/src/main/java/jakarta/enterprise/inject/spi/BeanContainer.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/BeanContainer.java
@@ -104,15 +104,15 @@ public interface BeanContainer {
     Set<Bean<?>> getBeans(Type beanType, Annotation... qualifiers);
 
     /**
-     * Return the set of beans which have the given EL name and are available for injection in the module or library containing
-     * the class into which the <code>BeanManager</code>/<code>BeanContainer</code> was injected or, in the Jakarta EE
-     * environment, the Jakarta EE component from whose JNDI environment namespace the
-     * <code>BeanManager</code>/<code>BeanContainer</code> was obtained, according to the rules of EL name resolution.
+     * Return the set of beans which have the given bean name and are available for injection in the module or library
+     * containing the class into which the <code>BeanManager</code>/<code>BeanContainer</code> was injected or, in
+     * the Jakarta EE environment, the Jakarta EE component from whose JNDI environment namespace the
+     * <code>BeanManager</code>/<code>BeanContainer</code> was obtained, according to the rules of name resolution.
      * <p>
      * Note that when called during invocation of an {@link AfterBeanDiscovery} event observer,
      * this method will only return beans discovered by the container before the {@link AfterBeanDiscovery} event is fired.
      *
-     * @param name the EL name
+     * @param name the bean name
      * @return the resulting set of {@linkplain Bean beans}
      * @throws IllegalStateException if called during application initialization, before the {@link AfterBeanDiscovery}
      *         event is fired.

--- a/el/src/main/java/jakarta/enterprise/inject/spi/el/ELAwareBeanManager.java
+++ b/el/src/main/java/jakarta/enterprise/inject/spi/el/ELAwareBeanManager.java
@@ -26,7 +26,7 @@ import jakarta.enterprise.inject.spi.BeanManager;
  */
 public interface ELAwareBeanManager extends BeanManager {
     /**
-     * Returns a {@link jakarta.el.ELResolver} that resolves beans by EL name.
+     * Returns a {@link jakarta.el.ELResolver} that resolves beans by bean name.
      *
      * @return the {@link jakarta.el.ELResolver}
      */


### PR DESCRIPTION
The specification text uses the term _bean name_. Some parts of the API used the old term _EL name_, which this commit rectifies.