### PR TITLE
bump to 5.0.0.Alpha2-SNAPSHOT

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -18,7 +18,7 @@
 	<parent>
 		<groupId>jakarta.enterprise</groupId>
 		<artifactId>jakarta.enterprise.cdi-parent</artifactId>
-		<version>5.0.0.Alpha1-SNAPSHOT</version>
+		<version>5.0.0.Alpha2-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>jakarta.enterprise.cdi-api</artifactId>

--- a/el/pom.xml
+++ b/el/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>jakarta.enterprise</groupId>
 		<artifactId>jakarta.enterprise.cdi-parent</artifactId>
-		<version>5.0.0.Alpha1-SNAPSHOT</version>
+		<version>5.0.0.Alpha2-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>jakarta.enterprise.cdi-el-api</artifactId>

--- a/ide-config/pom.xml
+++ b/ide-config/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>jakarta.enterprise</groupId>
         <artifactId>jakarta.enterprise.cdi-parent</artifactId>
-        <version>5.0.0.Alpha1-SNAPSHOT</version>
+        <version>5.0.0.Alpha2-SNAPSHOT</version>
     </parent>
 
     <artifactId>cdi-ide-config</artifactId>

--- a/lang-model/pom.xml
+++ b/lang-model/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>jakarta.enterprise</groupId>
 		<artifactId>jakarta.enterprise.cdi-parent</artifactId>
-		<version>5.0.0.Alpha1-SNAPSHOT</version>
+		<version>5.0.0.Alpha2-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>jakarta.enterprise.lang-model</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 	<groupId>jakarta.enterprise</groupId>
 	<artifactId>jakarta.enterprise.cdi-parent</artifactId>
 	<packaging>pom</packaging>
-	<version>5.0.0.Alpha1-SNAPSHOT</version>
+	<version>5.0.0.Alpha2-SNAPSHOT</version>
 
 	<description>Parent module for CDI Specification</description>
 

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>jakarta.enterprise</groupId>
 		<artifactId>jakarta.enterprise.cdi-parent</artifactId>
-		<version>5.0.0.Alpha1-SNAPSHOT</version>
+		<version>5.0.0.Alpha2-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>jakarta.enterprise.cdi-spec-doc</artifactId>


### PR DESCRIPTION
We've already released 5.0.0.Alpha1. It makes no sense for the current version string to be 5.0.0.Alpha1-SNAPSHOT. We're currently working towards 5.0.0.Alpha2, so that should be reflected in the version.