### PR TITLE
Provide a BeanContainer method to unwrap proxies

### DIFF
--- a/api/src/main/java/jakarta/enterprise/inject/spi/BeanContainer.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/BeanContainer.java
@@ -318,4 +318,15 @@ public interface BeanContainer {
      */
     boolean isMatchingEvent(Type specifiedType, Set<Annotation> specifiedQualifiers, Type observedEventType,
             Set<Annotation> observedEventQualifiers);
+
+    /**
+     * If the given {@code reference} is a client proxy for a bean, returns the contextual instance of the bean.
+     * Otherwise, including when {@code reference} is {@code null}, returns {@code reference} itself.
+     * <p>
+     * If the bean's scope is not active, this method rethrows the {@code ContextNotActiveException}
+     * or {@code IllegalStateException}.
+     *
+     * @param reference the client proxy to unwrap
+     */
+    <T> T unwrapClientProxy(T reference);
 }

--- a/spec/src/main/asciidoc/core/beanmanager_lite.asciidoc
+++ b/spec/src/main/asciidoc/core/beanmanager_lite.asciidoc
@@ -282,3 +282,16 @@ public boolean isMatchingBean(Set<Type> beanTypes, Set<Annotation> beanQualifier
 
 public boolean isMatchingEvent(Type eventType, Set<Annotation> eventQualifiers, Type observedEventType, Set<Annotation> observedEventQualifiers);
 ----
+
+[[bm_proxy_unwrap]]
+
+==== Unwrapping a client proxy
+
+Normal scoped beans use client proxies and the method `BeanContainer.unwrapClientProxy()` unwraps the proxy and returns the underlying contextual instance.
+
+NOTE: While this is useful for introspection of the contextual instance by frameworks/libraries, it should not be a common pattern to unwrap proxies and invoke business methods directly on contextual instances!
+
+[source, java]
+----
+public <T> T unwrapClientProxy(T reference);
+----


### PR DESCRIPTION
Fixes #860 

Javadoc is taken from the issue comment as I fully agree with the wording.
In the spec text I added a `NOTE` as I wanted to be clear that users shouldn't try to "bypass" the proxy this way.