### PR TITLE
State that vetoing an already specialized bean results in non-portable behavior

### DIFF
--- a/spec/src/main/asciidoc/core/spi_full.asciidoc
+++ b/spec/src/main/asciidoc/core/spi_full.asciidoc
@@ -1318,7 +1318,7 @@ public interface ProcessBeanAttributes<T> {
 * `configureBeanAttributes()` returns a `BeanAttributesConfigurator` (as defined in <<bean_attributes_configurator>>) initialized with the `BeanAttributes` processed by the event to easily configure the  `BeanAttributes` which will be used to replace the original one at the end of observer invocation.
 The method always returns the same `BeanAttributesConfigurator`.
 * `addDefinitionError()` registers a definition error with the container, causing the container to abort deployment after bean discovery is complete.
-* `veto()` forces the container to ignore the bean.
+* `veto()` forces the container to ignore the bean. If a bean that directly specializes another bean (as defined in <<specialization>>) is vetoed, non-portable behavior results.
 * `ignoreFinalMethods()` Instructs the container to ignore all non-static, final methods with public, protected or default visibility declared on any bean type of the specific bean during validation of injection points that require proxyable bean type.
 These method should never be invoked upon bean instances.
 Otherwise, unpredictable behavior results.


### PR DESCRIPTION
As per discussion in https://github.com/jakartaee/cdi/issues/893#issuecomment-3364915673

The original TCK challenge can be found here - https://github.com/jakartaee/cdi-tck/issues/440

Doing this will allow both interpretations to keep doing as they do while we can clear the TCK exclusion list (which is a requirement for M1 release).