### PR TITLE
fix the specification of alternatives

### DIFF
--- a/api/src/main/java/jakarta/enterprise/inject/Alternative.java
+++ b/api/src/main/java/jakarta/enterprise/inject/Alternative.java
@@ -23,6 +23,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import jakarta.annotation.Priority;
 import jakarta.enterprise.util.AnnotationLiteral;
 
 /**
@@ -33,20 +34,26 @@ import jakarta.enterprise.util.AnnotationLiteral;
  *
  * <pre>
  * &#064;Alternative
+ * &#064;Priority(1)
+ * &#064;Dependent
  * public class MockOrder extends Order { ... }
  * </pre>
  *
  * <p>
- * An alternative is not available for injection, lookup or EL resolution to classes or JSP/JSF pages in a module unless the
- * module is a bean archive and the alternative is explicitly <em>selected</em> in that bean archive. An alternative is never
- * available for injection, lookup or EL resolution in a module that is not a bean archive.
+ * During typesafe resolution, alternatives take precedence over other, non-alternative beans.
+ * </p>
+ *
+ * <p>
+ * An alternative is not available for injection, lookup or name resolution in a module unless
+ * the alternative is <em>selected</em> for the application (by adding the {@link Priority} annotation)
+ * or the module is a bean archive and the alternative is <em>selected</em> for that bean archive.
  * </p>
  *
  * <p>
  * By default, a bean archive has no selected alternatives. An alternative must be explicitly declared using the
  * <code>&lt;alternatives&gt;</code> element of the <code>beans.xml</code> file of the bean archive. The
- * <code>&lt;alternatives&gt;</code> element contains a list of bean classes and stereotypes. An alternative is selected for the
- * bean archive if either:
+ * <code>&lt;alternatives&gt;</code> element contains a list of bean classes and stereotypes. An alternative
+ * is selected for the bean archive if either:
  * </p>
  *
  * <ul>

--- a/spec/src/main/asciidoc/core/injectionandresolution.asciidoc
+++ b/spec/src/main/asciidoc/core/injectionandresolution.asciidoc
@@ -38,7 +38,7 @@ Other kinds of bean archives exist in {cdi_full}.
 
 A bean packaged in a certain module is available for injection, lookup and name resolution to classes packaged in some other module if and only if the bean class of the bean is required to be _accessible_ to the other module by the class accessibility requirements of the module architecture.
 
-An alternative is not available for injection, lookup or name resolution to classes in a module unless the module is a bean archive and the alternative is explicitly _selected_ for the application.
+An alternative is not available for injection, lookup or name resolution to classes in a module unless the alternative is _selected_ for the application.
 
 [[declaring_selected_alternatives]]
 

--- a/spec/src/main/asciidoc/core/injectionandresolution_full.asciidoc
+++ b/spec/src/main/asciidoc/core/injectionandresolution_full.asciidoc
@@ -20,7 +20,7 @@ In addition to rules defined in <<selection>>, the following rules apply.
 
 A library may be an explicit bean archive or an implicit bean archive, as defined in <<bean_archive_full>>.
 
-An alternative is not available for injection, lookup or name resolution to classes in a module unless the module is a bean archive and the alternative is explicitly _selected_ for the bean archive or the application.
+An alternative is not available for injection, lookup or name resolution to classes in a module unless the alternative is _selected_ for the application or the module is a bean archive and the alternative is _selected_ for that bean archive.
 
 [[declaring_selected_alternatives_full]]
 
@@ -112,7 +112,7 @@ A bean is _available for injection_ in a certain module if:
 
 * the bean is not an interceptor or decorator,
 * the bean is enabled,
-* the bean is either not an alternative, or the module is a bean archive and the bean is a selected alternative of the bean archive, or the bean is a selected alternative of the application, and
+* the bean is either not an alternative, or the bean is a selected alternative for the application, or the module is a bean archive and the bean is a selected alternative of the bean archive, and
 * the bean class is required to be accessible to classes in the module, according to the class accessibility requirements of the module architecture.
 
 For a custom implementation of the `Bean` interface defined in <<bean>>, the container calls `getBeanClass()` to determine the bean class of the bean and `InjectionPoint.getMember()` and then `Member.getDeclaringClass()` to determine the class that declares an injection point.


### PR DESCRIPTION
Certain parts of the specification said that alternatives are not available for injection to classes in an archive, unless the archive is a bean archive.

This usually doesn't matter, because if an archive is not a bean archive, beans in that archive are not discovered, but there's a set of "special" classes (such as servlets) for which injection should still happen, even if they are present in an archive that is not a bean archive.

This commit fixes that: alternative is available for injection into classes in an archive if it is selected for the application, or if that archive is a bean archive and the alternative is selected for that bean archive.

Fixes #882