### PR TITLE
Update parent project to bring in new release configuration; delete outdated configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
 	<packaging>pom</packaging>
 	<version>5.0.0.Alpha2-SNAPSHOT</version>
 
+	<name>CDI Parent</name>
 	<description>Parent module for CDI Specification</description>
 
 	<licenses>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -19,7 +19,7 @@
 	<artifactId>jakarta.enterprise.cdi-spec-doc</artifactId>
 	<packaging>pom</packaging>
 
-
+	<name>CDI Specification</name>
 	<description>CDI Specification documentation</description>
 
 	<properties>


### PR DESCRIPTION
The needed configuration should be a URL to new release repository and a new release plugin both if which are be present [in the new parent](https://github.com/eclipse-ee4j/ee4j/blob/main/parent/pom.xml).

Second commit adds `<name>` to modules that have none defined - IIRC, the Central Portal now requires this for every artifact.