### PR TITLE
Change GAV of CDI artifacts, provide relocation POMs for easier migration

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -35,3 +35,6 @@ jobs:
       - name: "Maven test"
         run: |
           mvn -Pstaging test -B
+      - name: "Maven test"
+        run: |
+          mvn -Pstaging install -DskipTests=true -Dno-format -B -V -f relocation/pom.xml

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -16,12 +16,12 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
-		<groupId>jakarta.enterprise</groupId>
-		<artifactId>jakarta.enterprise.cdi-parent</artifactId>
+		<groupId>jakarta.cdi</groupId>
+		<artifactId>jakarta.cdi-parent</artifactId>
 		<version>5.0.0.Beta1-SNAPSHOT</version>
 	</parent>
 
-	<artifactId>jakarta.enterprise.cdi-api</artifactId>
+	<artifactId>jakarta.cdi-api</artifactId>
 	<packaging>jar</packaging>
 
 	<name>CDI APIs</name>
@@ -135,8 +135,8 @@
 			</dependency>
 
 			<dependency>
-				<groupId>jakarta.enterprise</groupId>
-				<artifactId>jakarta.enterprise.lang-model</artifactId>
+				<groupId>jakarta.cdi</groupId>
+				<artifactId>jakarta.cdi-lang-model-api</artifactId>
 				<version>${project.version}</version>
 			</dependency>
 
@@ -162,8 +162,8 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>jakarta.enterprise</groupId>
-			<artifactId>jakarta.enterprise.lang-model</artifactId>
+			<groupId>jakarta.cdi</groupId>
+			<artifactId>jakarta.cdi-lang-model-api</artifactId>
 		</dependency>
 
 		<dependency>

--- a/el/pom.xml
+++ b/el/pom.xml
@@ -11,12 +11,12 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
-		<groupId>jakarta.enterprise</groupId>
-		<artifactId>jakarta.enterprise.cdi-parent</artifactId>
+		<groupId>jakarta.cdi</groupId>
+		<artifactId>jakarta.cdi-parent</artifactId>
 		<version>5.0.0.Beta1-SNAPSHOT</version>
 	</parent>
 
-	<artifactId>jakarta.enterprise.cdi-el-api</artifactId>
+	<artifactId>jakarta.cdi-el-api</artifactId>
 	<packaging>jar</packaging>
 
 	<name>CDI EL integration API</name>
@@ -33,8 +33,8 @@
 	<dependencyManagement>
 		<dependencies>
 			<dependency>
-				<groupId>jakarta.enterprise</groupId>
-				<artifactId>jakarta.enterprise.cdi-api</artifactId>
+				<groupId>jakarta.cdi</groupId>
+				<artifactId>jakarta.cdi-api</artifactId>
 				<version>${project.version}</version>
 			</dependency>
 			<dependency>
@@ -47,8 +47,8 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>jakarta.enterprise</groupId>
-			<artifactId>jakarta.enterprise.cdi-api</artifactId>
+			<groupId>jakarta.cdi</groupId>
+			<artifactId>jakarta.cdi-api</artifactId>
 		</dependency>
 
 		<dependency>

--- a/ide-config/pom.xml
+++ b/ide-config/pom.xml
@@ -12,12 +12,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>jakarta.enterprise</groupId>
-        <artifactId>jakarta.enterprise.cdi-parent</artifactId>
+        <groupId>jakarta.cdi</groupId>
+        <artifactId>jakarta.cdi-parent</artifactId>
         <version>5.0.0.Beta1-SNAPSHOT</version>
     </parent>
 
-    <artifactId>cdi-ide-config</artifactId>
+    <artifactId>jakarta.cdi-ide-config</artifactId>
 
     <name>CDI IDE Config</name>
     <description>Formatting config and import sorting</description>

--- a/lang-model/pom.xml
+++ b/lang-model/pom.xml
@@ -11,12 +11,12 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
-		<groupId>jakarta.enterprise</groupId>
-		<artifactId>jakarta.enterprise.cdi-parent</artifactId>
+		<groupId>jakarta.cdi</groupId>
+		<artifactId>jakarta.cdi-parent</artifactId>
 		<version>5.0.0.Beta1-SNAPSHOT</version>
 	</parent>
 
-	<artifactId>jakarta.enterprise.lang-model</artifactId>
+	<artifactId>jakarta.cdi-lang-model-api</artifactId>
 	<packaging>jar</packaging>
 
 	<name>CDI Language Model</name>

--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
 		<version>2.0.0-M1</version>
 	</parent>
 
-	<groupId>jakarta.enterprise</groupId>
-	<artifactId>jakarta.enterprise.cdi-parent</artifactId>
+	<groupId>jakarta.cdi</groupId>
+	<artifactId>jakarta.cdi-parent</artifactId>
 	<packaging>pom</packaging>
 	<version>5.0.0.Beta1-SNAPSHOT</version>
 
@@ -56,8 +56,8 @@
 					<version>${formatter.version}</version>
 					<dependencies>
 						<dependency>
-							<groupId>jakarta.enterprise</groupId>
-							<artifactId>cdi-ide-config</artifactId>
+							<groupId>jakarta.cdi</groupId>
+							<artifactId>jakarta.cdi-ide-config</artifactId>
 							<version>${project.version}</version>
 						</dependency>
 					</dependencies>

--- a/relocation/api/pom.xml
+++ b/relocation/api/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2025, Contributors to the Eclipse Foundation
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>jakarta.enterprise</groupId>
+        <artifactId>jakarta.enterprise.cdi-parent</artifactId>
+        <version>5.0.0.Beta1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>jakarta.enterprise.cdi-api</artifactId>
+    <packaging>pom</packaging>
+
+    <name>CDI APIs (Relocation)</name>
+    <description>APIs for CDI (Contexts and Dependency Injection for Java)</description>
+
+    <licenses>
+        <license>
+            <name>Apache License 2.0</name>
+            <url>https://repository.jboss.org/licenses/apache-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <distributionManagement>
+        <relocation>
+            <groupId>jakarta.cdi</groupId>
+            <artifactId>jakarta.cdi-api</artifactId>
+        </relocation>
+    </distributionManagement>
+</project>

--- a/relocation/el/pom.xml
+++ b/relocation/el/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2025, Contributors to the Eclipse Foundation
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>jakarta.enterprise</groupId>
+        <artifactId>jakarta.enterprise.cdi-parent</artifactId>
+        <version>5.0.0.Beta1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>jakarta.enterprise.cdi-el-api</artifactId>
+    <packaging>pom</packaging>
+
+    <name>CDI EL integration API (Relocation)</name>
+    <description>API for integrating CDI with Unified EL</description>
+
+    <licenses>
+        <license>
+            <name>Apache License 2.0</name>
+            <url>https://repository.jboss.org/licenses/apache-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <distributionManagement>
+        <relocation>
+            <groupId>jakarta.cdi</groupId>
+            <artifactId>jakarta.cdi-el-api</artifactId>
+        </relocation>
+    </distributionManagement>
+</project>

--- a/relocation/lang-model/pom.xml
+++ b/relocation/lang-model/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2025, Contributors to the Eclipse Foundation
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>jakarta.enterprise</groupId>
+        <artifactId>jakarta.enterprise.cdi-parent</artifactId>
+        <version>5.0.0.Beta1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>jakarta.enterprise.lang-model</artifactId>
+    <packaging>pom</packaging>
+
+    <name>CDI Language Model (Relocation)</name>
+    <description>Build Compatible (Reflection-Free) Java Language Model for CDI</description>
+
+    <licenses>
+        <license>
+            <name>Apache License 2.0</name>
+            <url>https://apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <distributionManagement>
+        <relocation>
+            <groupId>jakarta.cdi</groupId>
+            <artifactId>jakarta.cdi-lang-model-api</artifactId>
+        </relocation>
+    </distributionManagement>
+</project>

--- a/relocation/pom.xml
+++ b/relocation/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2025, Contributors to the Eclipse Foundation
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.eclipse.ee4j</groupId>
+        <artifactId>project</artifactId>
+        <version>2.0.0-M1</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>jakarta.enterprise</groupId>
+    <artifactId>jakarta.enterprise.cdi-parent</artifactId>
+    <packaging>pom</packaging>
+    <version>5.0.0.Beta1-SNAPSHOT</version>
+
+    <name>CDI Parent (Relocation)</name>
+    <description>Parent module for CDI Specification</description>
+
+    <licenses>
+        <license>
+            <name>Apache License 2.0</name>
+            <url>https://apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <distributionManagement>
+        <relocation>
+            <groupId>jakarta.cdi</groupId>
+            <artifactId>jakarta.cdi.parent</artifactId>
+        </relocation>
+    </distributionManagement>
+
+    <modules>
+        <module>api</module>
+        <module>el</module>
+        <module>spec</module>
+        <module>lang-model</module>
+    </modules>
+
+</project>

--- a/relocation/spec/pom.xml
+++ b/relocation/spec/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2025, Contributors to the Eclipse Foundation
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>jakarta.enterprise</groupId>
+        <artifactId>jakarta.enterprise.cdi-parent</artifactId>
+        <version>5.0.0.Beta1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>jakarta.enterprise.cdi-spec-doc</artifactId>
+    <packaging>pom</packaging>
+
+    <name>CDI Specification (Relocation)</name>
+    <description>CDI Specification documentation</description>
+
+    <licenses>
+        <license>
+            <name>Apache License 2.0</name>
+            <url>https://apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <distributionManagement>
+        <relocation>
+            <groupId>jakarta.cdi</groupId>
+            <artifactId>jakarta.cdi-spec-doc</artifactId>
+        </relocation>
+    </distributionManagement>
+</project>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -11,12 +11,12 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
-		<groupId>jakarta.enterprise</groupId>
-		<artifactId>jakarta.enterprise.cdi-parent</artifactId>
+		<groupId>jakarta.cdi</groupId>
+		<artifactId>jakarta.cdi-parent</artifactId>
 		<version>5.0.0.Beta1-SNAPSHOT</version>
 	</parent>
 
-	<artifactId>jakarta.enterprise.cdi-spec-doc</artifactId>
+	<artifactId>jakarta.cdi-spec-doc</artifactId>
 	<packaging>pom</packaging>
 
 	<name>CDI Specification</name>


### PR DESCRIPTION
Fixes #908

Changes group ID of all artifacts to `jakarta.cdi` and artifact IDs to `jakarta.cdi-[something]`.

Relocation modules are provided for all of the artifacts for ease of migration.
They should all have packaging `pom` to avoid creating empty JARs and should be built (and hence released by the Jenkins) along with the whole project build.

We will want to remove these modules as we get 5.0 out of the gate.
Their main purpose is to allow users to update their existing versions smoothly at which point they will start seeing a warning during the build informing them of the relocation.

Comments are welcome, this is the first time I am dealing with relocation modules so I might easily be wrong (although it does seem to work locally).