### PR TITLE
GAV change - fix javadoc POM file information

### DIFF
--- a/api/javadoc-pom.xml
+++ b/api/javadoc-pom.xml
@@ -13,20 +13,21 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.0-M1</version>
+        <relativePath/>
     </parent>
 
     <!-- A pom file to generate the combined JavaDoc for Jakarta CDI APIs from the individual API source artifacts:
-        jakarta.enterprise.cdi-api
-        jakarta.enterprise.cdi-el-api
-        jakarta.enterprise.lang-model
+        jakarta.cdi-api
+        jakarta.cdi-el-api
+        jakarta.cdi-lang-model-api
         The combined JavaDoc is generated in the target/all-apidocs directory.
 
         The CI release job will use this pom file to generate the combined JavaDoc for the Jakarta CDI APIs
         after the build of the
     -->
-    <groupId>jakarta.enterprise</groupId>
-    <artifactId>jakarta.enterprise.cdi-javadoc</artifactId>
+    <groupId>jakarta.cdi</groupId>
+    <artifactId>jakarta.cdi-javadoc</artifactId>
     <version>${releaseVersion}</version>
     <name>Jakarta CDI Combined JavaDoc</name>
     <description>Jakarta CDI Combined JavaDoc</description>
@@ -104,18 +105,18 @@ Use is subject to <a href="{@docRoot}/doc-files/speclicense.html" target="_top">
 
     <dependencies>
         <dependency>
-            <groupId>jakarta.enterprise</groupId>
-            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <groupId>jakarta.cdi</groupId>
+            <artifactId>jakarta.cdi-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>jakarta.enterprise</groupId>
-            <artifactId>jakarta.enterprise.cdi-el-api</artifactId>
+            <groupId>jakarta.cdi</groupId>
+            <artifactId>jakarta.cdi-el-api</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>jakarta.enterprise</groupId>
-            <artifactId>jakarta.enterprise.lang-model</artifactId>
+            <groupId>jakarta.cdi</groupId>
+            <artifactId>jakarta.cdi-lang-model-api</artifactId>
             <version>${project.version}</version>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Follow up to https://github.com/jakartaee/cdi/pull/913

Apparently I forgot to update this one POM file.
It's not a part of the standard build but it is used during release.