### PR TITLE
Add SCM information to the relocation parent

### DIFF
--- a/relocation/pom.xml
+++ b/relocation/pom.xml
@@ -39,6 +39,13 @@
         </license>
     </licenses>
 
+    <scm>
+        <connection>scm:git:git://github.com/eclipse-ee4j/cdi.git</connection>
+        <developerConnection>scm:git:git@github.com:eclipse-ee4j/cdi.git</developerConnection>
+        <url>https://github.com/eclipse-ee4j/cdi</url>
+        <tag>HEAD</tag>
+    </scm>
+
     <distributionManagement>
         <relocation>
             <groupId>jakarta.cdi</groupId>


### PR DESCRIPTION
The seems to be required for the release.
Note that the relocation CDI Parent does does not depend on the standard CDI Parent, so this SCM information will not be inherited.