### PR TITLE
improve performance of common annotation literals

### DIFF
--- a/api/src/main/java/jakarta/enterprise/context/ApplicationScoped.java
+++ b/api/src/main/java/jakarta/enterprise/context/ApplicationScoped.java
@@ -19,6 +19,7 @@ import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+import java.lang.annotation.Annotation;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
@@ -90,12 +91,31 @@ public @interface ApplicationScoped {
      * @author Martin Kouba
      * @since 2.0
      */
-    public final static class Literal extends AnnotationLiteral<ApplicationScoped> implements ApplicationScoped {
+    final class Literal extends AnnotationLiteral<ApplicationScoped> implements ApplicationScoped {
         /** Default ApplicationScoped literal */
         public static final Literal INSTANCE = new Literal();
 
         private static final long serialVersionUID = 1L;
 
+        public Class<? extends Annotation> annotationType() {
+            return ApplicationScoped.class;
+        }
+
+        public boolean equals(Object other) {
+            if (this == other) {
+                return true;
+            } else {
+                return other instanceof Annotation that && ApplicationScoped.class.equals(that.annotationType());
+            }
+        }
+
+        public int hashCode() {
+            return 0;
+        }
+
+        public String toString() {
+            return "@jakarta.enterprise.context.ApplicationScoped()";
+        }
     }
 
 }

--- a/api/src/main/java/jakarta/enterprise/context/BeforeDestroyed.java
+++ b/api/src/main/java/jakarta/enterprise/context/BeforeDestroyed.java
@@ -53,7 +53,7 @@ public @interface BeforeDestroyed {
     /**
      * Supports inline instantiation of the {@link BeforeDestroyed} qualifier.
      */
-    public final static class Literal extends AnnotationLiteral<BeforeDestroyed> implements BeforeDestroyed {
+    final class Literal extends AnnotationLiteral<BeforeDestroyed> implements BeforeDestroyed {
         /** Default BeforeDestroyed literal for the RequestScoped scope */
         public static final Literal REQUEST = of(RequestScoped.class);
 
@@ -87,6 +87,30 @@ public @interface BeforeDestroyed {
 
         public Class<? extends Annotation> value() {
             return value;
+        }
+
+        public Class<? extends Annotation> annotationType() {
+            return BeforeDestroyed.class;
+        }
+
+        public boolean equals(Object other) {
+            if (this == other) {
+                return true;
+            } else if (other instanceof BeforeDestroyed that) {
+                return this.value.equals(that.value());
+            } else {
+                return false;
+            }
+        }
+
+        public int hashCode() {
+            int result = 0;
+            result += 127 * "value".hashCode() ^ this.value.hashCode();
+            return result;
+        }
+
+        public String toString() {
+            return "@jakarta.enterprise.context.BeforeDestroyed(" + this.value.getName() + ".class)";
         }
     }
 

--- a/api/src/main/java/jakarta/enterprise/context/ConversationScoped.java
+++ b/api/src/main/java/jakarta/enterprise/context/ConversationScoped.java
@@ -19,6 +19,7 @@ import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+import java.lang.annotation.Annotation;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
@@ -150,12 +151,31 @@ public @interface ConversationScoped {
      * @author Martin Kouba
      * @since 2.0
      */
-    public final static class Literal extends AnnotationLiteral<ConversationScoped> implements ConversationScoped {
+    final class Literal extends AnnotationLiteral<ConversationScoped> implements ConversationScoped {
         /** Default ConversationScoped literal */
         public static final Literal INSTANCE = new Literal();
 
         private static final long serialVersionUID = 1L;
 
+        public Class<? extends Annotation> annotationType() {
+            return ConversationScoped.class;
+        }
+
+        public boolean equals(Object other) {
+            if (this == other) {
+                return true;
+            } else {
+                return other instanceof Annotation that && ConversationScoped.class.equals(that.annotationType());
+            }
+        }
+
+        public int hashCode() {
+            return 0;
+        }
+
+        public String toString() {
+            return "@jakarta.enterprise.context.ConversationScoped()";
+        }
     }
 
 }

--- a/api/src/main/java/jakarta/enterprise/context/Dependent.java
+++ b/api/src/main/java/jakarta/enterprise/context/Dependent.java
@@ -19,6 +19,7 @@ import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+import java.lang.annotation.Annotation;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
@@ -107,11 +108,30 @@ public @interface Dependent {
      * @author Martin Kouba
      * @since 2.0
      */
-    public final static class Literal extends AnnotationLiteral<Dependent> implements Dependent {
+    final class Literal extends AnnotationLiteral<Dependent> implements Dependent {
         /** Default Dependent literal */
         public static final Literal INSTANCE = new Literal();
 
         private static final long serialVersionUID = 1L;
 
+        public Class<? extends Annotation> annotationType() {
+            return Dependent.class;
+        }
+
+        public boolean equals(Object other) {
+            if (this == other) {
+                return true;
+            } else {
+                return other instanceof Annotation that && Dependent.class.equals(that.annotationType());
+            }
+        }
+
+        public int hashCode() {
+            return 0;
+        }
+
+        public String toString() {
+            return "@jakarta.enterprise.context.Dependent()";
+        }
     }
 }

--- a/api/src/main/java/jakarta/enterprise/context/Destroyed.java
+++ b/api/src/main/java/jakarta/enterprise/context/Destroyed.java
@@ -54,7 +54,7 @@ public @interface Destroyed {
      *
      * @author Martin Kouba
      */
-    public final static class Literal extends AnnotationLiteral<Destroyed> implements Destroyed {
+    final class Literal extends AnnotationLiteral<Destroyed> implements Destroyed {
         /** Default Destroyed literal for the RequestScoped scope */
         public static final Literal REQUEST = of(RequestScoped.class);
 
@@ -88,6 +88,30 @@ public @interface Destroyed {
 
         public Class<? extends Annotation> value() {
             return value;
+        }
+
+        public Class<? extends Annotation> annotationType() {
+            return Destroyed.class;
+        }
+
+        public boolean equals(Object other) {
+            if (this == other) {
+                return true;
+            } else if (other instanceof Destroyed that) {
+                return this.value.equals(that.value());
+            } else {
+                return false;
+            }
+        }
+
+        public int hashCode() {
+            int result = 0;
+            result += 127 * "value".hashCode() ^ this.value.hashCode();
+            return result;
+        }
+
+        public String toString() {
+            return "@jakarta.enterprise.context.Destroyed(" + this.value.getName() + ".class)";
         }
     }
 

--- a/api/src/main/java/jakarta/enterprise/context/Initialized.java
+++ b/api/src/main/java/jakarta/enterprise/context/Initialized.java
@@ -54,7 +54,7 @@ public @interface Initialized {
      *
      * @author Martin Kouba
      */
-    public final static class Literal extends AnnotationLiteral<Initialized> implements Initialized {
+    final class Literal extends AnnotationLiteral<Initialized> implements Initialized {
         /** Default Initialized literal for the RequestScoped scope */
         public static final Literal REQUEST = of(RequestScoped.class);
 
@@ -88,6 +88,30 @@ public @interface Initialized {
 
         public Class<? extends Annotation> value() {
             return value;
+        }
+
+        public Class<? extends Annotation> annotationType() {
+            return Initialized.class;
+        }
+
+        public boolean equals(Object other) {
+            if (this == other) {
+                return true;
+            } else if (other instanceof Initialized that) {
+                return this.value.equals(that.value());
+            } else {
+                return false;
+            }
+        }
+
+        public int hashCode() {
+            int result = 0;
+            result += 127 * "value".hashCode() ^ this.value.hashCode();
+            return result;
+        }
+
+        public String toString() {
+            return "@jakarta.enterprise.context.Initialized(" + this.value.getName() + ".class)";
         }
     }
 

--- a/api/src/main/java/jakarta/enterprise/context/RequestScoped.java
+++ b/api/src/main/java/jakarta/enterprise/context/RequestScoped.java
@@ -19,6 +19,7 @@ import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+import java.lang.annotation.Annotation;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
@@ -94,12 +95,31 @@ public @interface RequestScoped {
      * @author Martin Kouba
      * @since 2.0
      */
-    public final static class Literal extends AnnotationLiteral<RequestScoped> implements RequestScoped {
+    final class Literal extends AnnotationLiteral<RequestScoped> implements RequestScoped {
         /** Default RequestScoped literal */
         public static final Literal INSTANCE = new Literal();
 
         private static final long serialVersionUID = 1L;
 
+        public Class<? extends Annotation> annotationType() {
+            return RequestScoped.class;
+        }
+
+        public boolean equals(Object other) {
+            if (this == other) {
+                return true;
+            } else {
+                return other instanceof Annotation that && RequestScoped.class.equals(that.annotationType());
+            }
+        }
+
+        public int hashCode() {
+            return 0;
+        }
+
+        public String toString() {
+            return "@jakarta.enterprise.context.RequestScoped()";
+        }
     }
 
 }

--- a/api/src/main/java/jakarta/enterprise/context/SessionScoped.java
+++ b/api/src/main/java/jakarta/enterprise/context/SessionScoped.java
@@ -19,6 +19,7 @@ import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+import java.lang.annotation.Annotation;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
@@ -86,12 +87,31 @@ public @interface SessionScoped {
      * @author Martin Kouba
      * @since 2.0
      */
-    public final static class Literal extends AnnotationLiteral<SessionScoped> implements SessionScoped {
+    final class Literal extends AnnotationLiteral<SessionScoped> implements SessionScoped {
         /** Default SessionScoped literal */
         public static final Literal INSTANCE = new Literal();
 
         private static final long serialVersionUID = 1L;
 
+        public Class<? extends Annotation> annotationType() {
+            return SessionScoped.class;
+        }
+
+        public boolean equals(Object other) {
+            if (this == other) {
+                return true;
+            } else {
+                return other instanceof Annotation that && SessionScoped.class.equals(that.annotationType());
+            }
+        }
+
+        public int hashCode() {
+            return 0;
+        }
+
+        public String toString() {
+            return "@jakarta.enterprise.context.SessionScoped()";
+        }
     }
 
 }

--- a/api/src/main/java/jakarta/enterprise/inject/Alternative.java
+++ b/api/src/main/java/jakarta/enterprise/inject/Alternative.java
@@ -19,6 +19,7 @@ import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+import java.lang.annotation.Annotation;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -77,12 +78,31 @@ public @interface Alternative {
      * @author Martin Kouba
      * @since 2.0
      */
-    public final static class Literal extends AnnotationLiteral<Alternative> implements Alternative {
+    final class Literal extends AnnotationLiteral<Alternative> implements Alternative {
         /** Default Alternative literal */
         public static final Literal INSTANCE = new Literal();
 
         private static final long serialVersionUID = 1L;
 
+        public Class<? extends Annotation> annotationType() {
+            return Alternative.class;
+        }
+
+        public boolean equals(Object other) {
+            if (this == other) {
+                return true;
+            } else {
+                return other instanceof Annotation that && Alternative.class.equals(that.annotationType());
+            }
+        }
+
+        public int hashCode() {
+            return 0;
+        }
+
+        public String toString() {
+            return "@jakarta.enterprise.inject.Alternative()";
+        }
     }
 
 }

--- a/api/src/main/java/jakarta/enterprise/inject/Any.java
+++ b/api/src/main/java/jakarta/enterprise/inject/Any.java
@@ -20,6 +20,7 @@ import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+import java.lang.annotation.Annotation;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -82,12 +83,31 @@ public @interface Any {
      * @see Instance
      * @see Event
      */
-    public static final class Literal extends AnnotationLiteral<Any> implements Any {
+    final class Literal extends AnnotationLiteral<Any> implements Any {
         /** Default Any literal */
         public static final Literal INSTANCE = new Literal();
 
         private static final long serialVersionUID = 1L;
 
+        public Class<? extends Annotation> annotationType() {
+            return Any.class;
+        }
+
+        public boolean equals(Object other) {
+            if (this == other) {
+                return true;
+            } else {
+                return other instanceof Annotation that && Any.class.equals(that.annotationType());
+            }
+        }
+
+        public int hashCode() {
+            return 0;
+        }
+
+        public String toString() {
+            return "@jakarta.enterprise.inject.Any()";
+        }
     }
 
 }

--- a/api/src/main/java/jakarta/enterprise/inject/Default.java
+++ b/api/src/main/java/jakarta/enterprise/inject/Default.java
@@ -20,6 +20,7 @@ import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+import java.lang.annotation.Annotation;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -98,11 +99,30 @@ public @interface Default {
      * @see Instance
      * @see Event
      */
-    public static final class Literal extends AnnotationLiteral<Default> implements Default {
+    final class Literal extends AnnotationLiteral<Default> implements Default {
         /** The default Default literal */
         public static final Literal INSTANCE = new Literal();
 
         private static final long serialVersionUID = 1L;
 
+        public Class<? extends Annotation> annotationType() {
+            return Default.class;
+        }
+
+        public boolean equals(Object other) {
+            if (this == other) {
+                return true;
+            } else {
+                return other instanceof Annotation that && Default.class.equals(that.annotationType());
+            }
+        }
+
+        public int hashCode() {
+            return 0;
+        }
+
+        public String toString() {
+            return "@jakarta.enterprise.inject.Default()";
+        }
     }
 }

--- a/api/src/main/java/jakarta/enterprise/inject/Reserve.java
+++ b/api/src/main/java/jakarta/enterprise/inject/Reserve.java
@@ -15,6 +15,7 @@ import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+import java.lang.annotation.Annotation;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -59,5 +60,25 @@ public @interface Reserve {
         public static final Literal INSTANCE = new Literal();
 
         private static final long serialVersionUID = 1L;
+
+        public Class<? extends Annotation> annotationType() {
+            return Reserve.class;
+        }
+
+        public boolean equals(Object other) {
+            if (this == other) {
+                return true;
+            } else {
+                return other instanceof Annotation that && Reserve.class.equals(that.annotationType());
+            }
+        }
+
+        public int hashCode() {
+            return 0;
+        }
+
+        public String toString() {
+            return "@jakarta.enterprise.inject.Reserve()";
+        }
     }
 }

--- a/api/src/main/java/jakarta/enterprise/inject/Specializes.java
+++ b/api/src/main/java/jakarta/enterprise/inject/Specializes.java
@@ -18,6 +18,7 @@ import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+import java.lang.annotation.Annotation;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -80,11 +81,30 @@ public @interface Specializes {
      * @see Instance
      * @see Event
      */
-    public static final class Literal extends AnnotationLiteral<Specializes> implements Specializes {
+    final class Literal extends AnnotationLiteral<Specializes> implements Specializes {
 
         private static final long serialVersionUID = 1L;
         /** Default Specializes literal */
         public static final Literal INSTANCE = new Literal();
 
+        public Class<? extends Annotation> annotationType() {
+            return Specializes.class;
+        }
+
+        public boolean equals(Object other) {
+            if (this == other) {
+                return true;
+            } else {
+                return other instanceof Annotation that && Specializes.class.equals(that.annotationType());
+            }
+        }
+
+        public int hashCode() {
+            return 0;
+        }
+
+        public String toString() {
+            return "@jakarta.enterprise.inject.Specializes()";
+        }
     }
 }

--- a/api/src/main/java/jakarta/enterprise/inject/TransientReference.java
+++ b/api/src/main/java/jakarta/enterprise/inject/TransientReference.java
@@ -17,6 +17,7 @@ package jakarta.enterprise.inject;
 import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+import java.lang.annotation.Annotation;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -59,12 +60,30 @@ public @interface TransientReference {
      * @see Instance
      * @see Event
      */
-    public static final class Literal extends AnnotationLiteral<TransientReference> implements TransientReference {
-
+    final class Literal extends AnnotationLiteral<TransientReference> implements TransientReference {
         private static final long serialVersionUID = 1L;
         /** Default TransientReference literal */
         public static final Literal INSTANCE = new Literal();
 
+        public Class<? extends Annotation> annotationType() {
+            return TransientReference.class;
+        }
+
+        public boolean equals(Object other) {
+            if (this == other) {
+                return true;
+            } else {
+                return other instanceof Annotation that && TransientReference.class.equals(that.annotationType());
+            }
+        }
+
+        public int hashCode() {
+            return 0;
+        }
+
+        public String toString() {
+            return "@jakarta.enterprise.inject.TransientReference()";
+        }
     }
 
 }

--- a/api/src/main/java/jakarta/enterprise/inject/Typed.java
+++ b/api/src/main/java/jakarta/enterprise/inject/Typed.java
@@ -19,9 +19,11 @@ import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+import java.lang.annotation.Annotation;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
+import java.util.Arrays;
 
 import jakarta.enterprise.util.AnnotationLiteral;
 
@@ -68,7 +70,7 @@ public @interface Typed {
      * @author Martin Kouba
      * @since 2.0
      */
-    public final static class Literal extends AnnotationLiteral<Typed> implements Typed {
+    final class Literal extends AnnotationLiteral<Typed> implements Typed {
         /** Default Typed literal */
         public static final Literal INSTANCE = of(new Class<?>[] {});
 
@@ -96,6 +98,40 @@ public @interface Typed {
          */
         public Class<?>[] value() {
             return value;
+        }
+
+        public Class<? extends Annotation> annotationType() {
+            return Typed.class;
+        }
+
+        public boolean equals(Object other) {
+            if (this == other) {
+                return true;
+            } else if (other instanceof Typed that) {
+                return Arrays.equals(this.value, that.value());
+            } else {
+                return false;
+            }
+        }
+
+        public int hashCode() {
+            int result = 0;
+            result += 127 * "value".hashCode() ^ Arrays.hashCode(this.value);
+            return result;
+        }
+
+        public String toString() {
+            StringBuilder result = new StringBuilder("@jakarta.enterprise.inject.Typed({");
+            boolean first = true;
+            for (Class<?> clazz : this.value) {
+                if (!first) {
+                    result.append(", ");
+                }
+                result.append(clazz.getName()).append(".class");
+                first = false;
+            }
+            result.append("})");
+            return result.toString();
         }
     }
 

--- a/api/src/main/java/jakarta/enterprise/inject/Vetoed.java
+++ b/api/src/main/java/jakarta/enterprise/inject/Vetoed.java
@@ -14,6 +14,7 @@
 
 package jakarta.enterprise.inject;
 
+import java.lang.annotation.Annotation;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -55,12 +56,30 @@ public @interface Vetoed {
      * @see Instance
      * @see Event
      */
-    public static final class Literal extends AnnotationLiteral<Vetoed> implements Vetoed {
-
+    final class Literal extends AnnotationLiteral<Vetoed> implements Vetoed {
         private static final long serialVersionUID = 1L;
         /** Default Vetoed literal */
         public static final Literal INSTANCE = new Literal();
 
+        public Class<? extends Annotation> annotationType() {
+            return Vetoed.class;
+        }
+
+        public boolean equals(Object other) {
+            if (this == other) {
+                return true;
+            } else {
+                return other instanceof Annotation that && Vetoed.class.equals(that.annotationType());
+            }
+        }
+
+        public int hashCode() {
+            return 0;
+        }
+
+        public String toString() {
+            return "@jakarta.enterprise.inject.Vetoed()";
+        }
     }
 
 }

--- a/api/src/main/java/jakarta/enterprise/inject/literal/InjectLiteral.java
+++ b/api/src/main/java/jakarta/enterprise/inject/literal/InjectLiteral.java
@@ -13,6 +13,8 @@
  */
 package jakarta.enterprise.inject.literal;
 
+import java.lang.annotation.Annotation;
+
 import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Inject;
 
@@ -28,4 +30,23 @@ public final class InjectLiteral extends AnnotationLiteral<Inject> implements In
 
     private static final long serialVersionUID = 1L;
 
+    public Class<? extends Annotation> annotationType() {
+        return Inject.class;
+    }
+
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        } else {
+            return other instanceof Annotation that && Inject.class.equals(that.annotationType());
+        }
+    }
+
+    public int hashCode() {
+        return 0;
+    }
+
+    public String toString() {
+        return "@jakarta.inject.Inject()";
+    }
 }

--- a/api/src/main/java/jakarta/enterprise/inject/literal/NamedLiteral.java
+++ b/api/src/main/java/jakarta/enterprise/inject/literal/NamedLiteral.java
@@ -13,6 +13,8 @@
  */
 package jakarta.enterprise.inject.literal;
 
+import java.lang.annotation.Annotation;
+
 import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Named;
 
@@ -42,12 +44,35 @@ public final class NamedLiteral extends AnnotationLiteral<Named> implements Name
         return new NamedLiteral(value);
     }
 
-    public String value() {
-        return value;
-    }
-
     private NamedLiteral(String value) {
         this.value = value;
     }
 
+    public String value() {
+        return value;
+    }
+
+    public Class<? extends Annotation> annotationType() {
+        return Named.class;
+    }
+
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        } else if (other instanceof Named that) {
+            return this.value.equals(that.value());
+        } else {
+            return false;
+        }
+    }
+
+    public int hashCode() {
+        int result = 0;
+        result += 127 * "value".hashCode() ^ this.value.hashCode();
+        return result;
+    }
+
+    public String toString() {
+        return "@jakarta.inject.Named(\"" + this.value + "\")";
+    }
 }

--- a/api/src/main/java/jakarta/enterprise/inject/literal/QualifierLiteral.java
+++ b/api/src/main/java/jakarta/enterprise/inject/literal/QualifierLiteral.java
@@ -13,6 +13,8 @@
  */
 package jakarta.enterprise.inject.literal;
 
+import java.lang.annotation.Annotation;
+
 import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Qualifier;
 
@@ -28,4 +30,23 @@ public final class QualifierLiteral extends AnnotationLiteral<Qualifier> impleme
 
     private static final long serialVersionUID = 1L;
 
+    public Class<? extends Annotation> annotationType() {
+        return Qualifier.class;
+    }
+
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        } else {
+            return other instanceof Annotation that && Qualifier.class.equals(that.annotationType());
+        }
+    }
+
+    public int hashCode() {
+        return 0;
+    }
+
+    public String toString() {
+        return "@jakarta.inject.Qualifier()";
+    }
 }

--- a/api/src/main/java/jakarta/enterprise/inject/literal/SingletonLiteral.java
+++ b/api/src/main/java/jakarta/enterprise/inject/literal/SingletonLiteral.java
@@ -13,6 +13,8 @@
  */
 package jakarta.enterprise.inject.literal;
 
+import java.lang.annotation.Annotation;
+
 import jakarta.enterprise.util.AnnotationLiteral;
 import jakarta.inject.Singleton;
 
@@ -28,4 +30,23 @@ public final class SingletonLiteral extends AnnotationLiteral<Singleton> impleme
 
     private static final long serialVersionUID = 1L;
 
+    public Class<? extends Annotation> annotationType() {
+        return Singleton.class;
+    }
+
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        } else {
+            return other instanceof Annotation that && Singleton.class.equals(that.annotationType());
+        }
+    }
+
+    public int hashCode() {
+        return 0;
+    }
+
+    public String toString() {
+        return "@jakarta.inject.Singleton()";
+    }
 }

--- a/api/src/main/java/jakarta/enterprise/util/Nonbinding.java
+++ b/api/src/main/java/jakarta/enterprise/util/Nonbinding.java
@@ -17,6 +17,7 @@ package jakarta.enterprise.util;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+import java.lang.annotation.Annotation;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
@@ -55,11 +56,30 @@ public @interface Nonbinding {
      * @author Martin Kouba
      * @since 2.0
      */
-    public static final class Literal extends AnnotationLiteral<Nonbinding> implements Nonbinding {
+    final class Literal extends AnnotationLiteral<Nonbinding> implements Nonbinding {
         /** Default Nonbinding literal */
         public static final Literal INSTANCE = new Literal();
 
         private static final long serialVersionUID = 1L;
 
+        public Class<? extends Annotation> annotationType() {
+            return Nonbinding.class;
+        }
+
+        public boolean equals(Object other) {
+            if (this == other) {
+                return true;
+            } else {
+                return other instanceof Annotation that && Nonbinding.class.equals(that.annotationType());
+            }
+        }
+
+        public int hashCode() {
+            return 0;
+        }
+
+        public String toString() {
+            return "@jakarta.enterprise.util.Nonbinding()";
+        }
     }
 }


### PR DESCRIPTION
The `AnnotationLiteral` class provides reflective implementation of all useful methods: `annotationType()`, `equals()`, `hashCode()` and `toString()`. This implementation is generic, but also doesn't perform nearly as well as a direct implementation.

This commit provides direct implementation of these methods for all annotation literals that exist in this project. The new implementation is compatible with the old one in nearly all aspects, except:

- `equals()` for annotations that have members no longer checks for equality of `annotationType()`; instead, it uses `instanceof`
- return values of `toString()` may be slightly different, because they are aligned with the standard `Annotation.toString()` behavior (on JDK 17)

Note that for memberless annotations, `instanceof` is not used; the code still tests equality of `annotationType()`, similarly to how `AnnotationLiteral` works. This is because for memberless annotations, it is relatively common for `AnnotationLiteral` implementations that don't implement the annotation interface to exist, because they can easily be created as anonymous classes. It is technically possible to create an anonymous subclass for annotations with members, but the `AnnotationLiteral.getMembers()` method throws in such case, so the generic implementations are guaranteed to not work. Note that creating an `AnnotationLiteral` that doesn't implement the annotation interface breaks the `Annotation` contract and so should not be relied upon.

It would be posisble to break compatibility more (e.g. the new implementations no longer have to extend `AnnotationLiteral`), but this commit intentionally stays conservative.