### PR TITLE
introduce global scopes and improve application scope

### DIFF
--- a/api/src/main/java/jakarta/enterprise/context/ApplicationScoped.java
+++ b/api/src/main/java/jakarta/enterprise/context/ApplicationScoped.java
@@ -31,41 +31,16 @@ import jakarta.enterprise.util.AnnotationLiteral;
  * <p>
  * Specifies that a bean is application scoped.
  * </p>
+ *
  * <p>
- * While <code>ApplicationScoped</code> must be associated with the built-in application context required by the specification,
- * third-party extensions are allowed to also associate it with their own context. Behavior described below is only related to
- * the built-in application context.
+ * The application scope is global. Extensions are not allowed to register a custom context for it.
  * </p>
  *
  * <p>
- * The application scope is active:
- * </p>
- *
- * <ul>
- * <li>during the <code>service()</code> method of any servlet in the web application, during the <code>doFilter()</code> method
- * of any servlet filter and when the container calls any <code>ServletContextListener</code>, <code>HttpSessionListener</code>,
- * <code>AsyncListener</code> or <code>ServletRequestListener</code>,</li>
- * <li>during any Java EE web service invocation,</li>
- * <li>during any remote method invocation of any EJB, during any asynchronous method invocation of any EJB, during any call to
- * an EJB timeout method and during message delivery to any EJB message-driven bean,</li>
- * <li>when the disposer method or <code>@PreDestroy</code> callback of any bean with any normal scope other than
- * <code>@ApplicationScoped</code> is called, and</li>
- * <li>during <code>@PostConstruct</code> callback of any bean.</li>
- * </ul>
- *
- * <p>
- * The application context is shared between all servlet requests, web service invocations, EJB remote method invocations, EJB
- * asynchronous method invocations, EJB timeouts and message deliveries to message-driven beans that execute within the same
- * application.
- * </p>
- * <p>
- * The application context is destroyed when the application is shut down.
- * </p>
- *
- * <p>
- * An event with qualifier <code>@Initialized(ApplicationScoped.class)</code> is fired when the application context is
- * initialized and an event with qualifier <code>@Destroyed(ApplicationScoped.class)</code> when the application context is
- * destroyed. The event payload is:
+ * An event with qualifier {@code @Initialized(ApplicationScoped.class)} is fired after the application context
+ * is initialized. An event with qualifier {@code @BeforeDestroyed(ApplicationScoped.class)} is fired before
+ * the application context is destroyed. An event with qualifier {@code @Destroyed(ApplicationScoped.class)} is fired
+ * after the application context is destroyed. In all cases, the event payload is:
  * </p>
  *
  * <ul>

--- a/api/src/main/java/jakarta/enterprise/context/Dependent.java
+++ b/api/src/main/java/jakarta/enterprise/context/Dependent.java
@@ -67,7 +67,7 @@ import jakarta.inject.Scope;
  * </p>
  *
  * <p>
- * The <code>@Dependent</code> scope is always active.
+ * The dependent scope is global. Extensions are not allowed to register a custom context for it.
  * </p>
  *
  * <p>

--- a/api/src/main/java/jakarta/enterprise/context/control/ActivateRequestContext.java
+++ b/api/src/main/java/jakarta/enterprise/context/control/ActivateRequestContext.java
@@ -25,7 +25,7 @@ import java.lang.annotation.Target;
 import jakarta.interceptor.InterceptorBinding;
 
 /**
- * The container provides a built in interceptor that may be used to annotate classes and methods to indicate
+ * The container provides a built-in interceptor that may be used to annotate classes and methods to indicate
  * that a request context should be activated when this method is invoked.
  *
  * The request context will be activated before the method is called, and deactivated when the method invocation is

--- a/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/MetaAnnotations.java
+++ b/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/MetaAnnotations.java
@@ -70,6 +70,8 @@ public interface MetaAnnotations {
      *
      * @param scopeAnnotation the scope annotation type, must not be {@code null}
      * @param contextClass the context class, must not be {@code null}
+     * @throws jakarta.enterprise.inject.spi.DeploymentException if the {@code scopeAnnotation} represents
+     *         a global built-in scope
      * @throws IllegalArgumentException if the {@code scopeAnnotation} is not meta-annotated {@code @NormalScope}
      *         or {@code @Scope}
      */
@@ -86,6 +88,8 @@ public interface MetaAnnotations {
      * @param scopeAnnotation the scope annotation type, must not be {@code null}
      * @param isNormal whether the scope is normal
      * @param contextClass the context class, must not be {@code null}
+     * @throws jakarta.enterprise.inject.spi.DeploymentException if the {@code scopeAnnotation} represents
+     *         a global built-in scope
      */
     void addContext(Class<? extends Annotation> scopeAnnotation, boolean isNormal,
             Class<? extends AlterableContext> contextClass);

--- a/api/src/main/java/jakarta/enterprise/inject/spi/AfterBeanDiscovery.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/AfterBeanDiscovery.java
@@ -117,6 +117,7 @@ public interface AfterBeanDiscovery {
      * Registers a custom {@link Context} object with the container.
      *
      * @param context The custom context to add to the deployment
+     * @throws DeploymentException if the custom context declares a global built-in scope
      * @throws IllegalStateException if called outside of the observer method invocation
      */
     public void addContext(Context context);

--- a/spec/src/main/asciidoc/core/scopescontexts.asciidoc
+++ b/spec/src/main/asciidoc/core/scopescontexts.asciidoc
@@ -166,6 +166,17 @@ All pseudo-scopes must be explicitly declared `@Scope`, to indicate to the conta
 
 All scopes defined by this specification, except for the `@Dependent` pseudo-scope, are normal scopes.
 
+[[global_scope]]
+
+=== Global scopes
+
+Several scopes defined by this specification are _global_.
+A global scope has exactly one context object, which is:
+
+* initialized once, when the container starts up, before the event with qualifier `@Initialized(ApplicationScoped.class)` is fired,
+* destroyed once, when the container shuts down, after the event with qualifier `@BeforeDestroyed(ApplicationScoped.class)` is fired,
+* active on all application threads from the point the context object is initialized until it is destroyed.
+
 [[dependent_context]]
 
 === Dependent pseudo-scope
@@ -184,7 +195,7 @@ Every invocation of the `get()` operation of the `Context` object for the `@Depe
 
 Every invocation of the `get()` operation of the `Context` object for the `@Dependent` scope with no `CreationalContext` returns a null value.
 
-The `@Dependent` scope is always active.
+The `@Dependent` scope is global.
 
 [[dependent_objects]]
 
@@ -235,11 +246,11 @@ If there is exactly one active instance of `Context` associated with the scope t
 
 [[activating_builtin_contexts]]
 
-==== Activating Built In Contexts
+==== Activating Built-in Contexts
 
-Certain built in contexts support the ability to be activated and deactivated.  This allows developers to control built-in contexts in ways that they could also manage custom built contexts.
+Certain built-in contexts support the ability to be activated and deactivated.  This allows developers to control built-in contexts in ways that they could also manage custom built contexts.
 
-When activating and deactivating built in contexts, it is important to realize that they can only be activated if not already active within a given thread.
+When activating and deactivating built-in contexts, it is important to realize that they can only be activated if not already active within a given thread.
 
 [[activating_request_context]]
 
@@ -247,7 +258,7 @@ When activating and deactivating built in contexts, it is important to realize t
 
 Request contexts can be managed either programmatically or via interceptor.
 
-To programmatically manage request contexts, the container provides a built in bean that is `@Dependent` scoped and of type `RequestContextController` that allows you to activate and deactivate a request context on the current thread.  The object should be considered stateful, invoking the same instance on different threads may not work properly, non-portable behavior may occur.
+To programmatically manage request contexts, the container provides a built-in bean that is `@Dependent` scoped and of type `RequestContextController` that allows you to activate and deactivate a request context on the current thread.  The object should be considered stateful, invoking the same instance on different threads may not work properly, non-portable behavior may occur.
 
 [source, java]
 ----
@@ -390,11 +401,17 @@ The request context is destroyed:
 
 ==== Application context lifecycle
 
+The application scope is global.
+
 The _application context_ is provided by a built-in context object for the built-in scope type `@ApplicationScoped`.
 
 An event with qualifier `@Initialized(ApplicationScoped.class)` is synchronously fired when the application context is initialized.
 An event with qualifier `@BeforeDestroyed(ApplicationScoped.class)` is synchronously fired when the application context is about to be destroyed, i.e. before the actual destruction.
 An event with qualifier `@Destroyed(ApplicationScoped.class)` is synchronously fired when the application context is destroyed, i.e. after the actual destruction.
+
+The payload of the event fired when the application context is initialized or destroyed is:
+
+* any `java.lang.Object`.
 
 [[custom_contexts]]
 
@@ -410,4 +427,6 @@ where `X` is the scope type associated with the context.
 
 A suitable event payload should be chosen.
 
-Build compatible extensions may define custom context classes for custom scopes, but they may not define custom context classes for built-in scopes.
+Build compatible extensions may define custom context classes for non-global built-in scopes and for custom scopes.
+For example, a remoting framework might provide a request context object for the built-in request scope.
+If an attempt to register a custom context class for a global built-in scope is made, deployment problem occurs.

--- a/spec/src/main/asciidoc/core/scopescontexts_full.asciidoc
+++ b/spec/src/main/asciidoc/core/scopescontexts_full.asciidoc
@@ -29,7 +29,7 @@ When the container calls `get()` or `destroy()` for a context that is associated
 
 The `Context` interface may be called by portable extensions.
 
-A context object may be defined for any of the built-in scopes and registered with the container using the `AfterBeanDiscovery` event as described in <<after_bean_discovery>>.
+A context object may be defined for any of the non-global built-in scopes and registered with the container using the `AfterBeanDiscovery` event as described in <<after_bean_discovery>>.
 
 [[dependent_context_full]]
 
@@ -218,5 +218,6 @@ If `begin()` is called with an explicit conversation identifier, and a long-runn
 
 In addition to rules defined in <<custom_contexts>>, the following rule applies.
 
-A portable extension may define a custom context object for built-in scopes and custom scopes.
+A portable extension may define a custom context object for non-global built-in scopes and for custom scopes.
 For example, a remoting framework might provide a request context object for the built-in request scope.
+If an attempt to register a custom context object for a global built-in scope is made, deployment problem occurs.

--- a/spec/src/main/asciidoc/javase/scopescontext_se.asciidoc
+++ b/spec/src/main/asciidoc/javase/scopescontext_se.asciidoc
@@ -11,27 +11,10 @@ SPDX-License-Identifier: Apache-2.0
 
 == Scopes and contexts in Java SE
 
-[[builtin_contexts_se]]
+[[global_scope_se]]
 
-=== Context management for built-in scopes in Java SE
+=== Global scopes in Java SE
 
-When running in Java SE, the container must extend the rules defined in <<builtin_contexts>> and is also required to ensure the following rules for built-in context implementation.
+In addition to rules defined in <<global_scope>>, the following rules apply.
 
-[[application_context_se]]
-
-==== Application context lifecycle in Java SE
-
-When running in Java SE the container must extend the rules defined in <<application_context>> and is also required to ensure the following rules.
-
-The application scope is active:
-
-* during any method invocation
-
-The application context is shared between all method invocations that execute within the same container.
-
-The application context is destroyed when the container is shut down.
-
-The payload of the event fired when the application context is initialized or destroyed is:
-
-* any `java.lang.Object`.
-
+A context object for a global scope only exists within a container and is not active in other containers.


### PR DESCRIPTION
This commit introduces the notion of _global scopes_, for which exactly one context object exists and is active on all application threads since startup until shutdown. Extensions may not register context objects for built-in
global scopes.

The dependent context was previously specified to be "always active", which is not very precise. The dependent context is now global, for which a more precise specification exists (per above).

The application scope is now also global. This makes the specification simpler, more useful (other specifications may rely on the application scope being "always" active) and more aligned with existing implementations (they already prevent registering custom application contexts).

The specification never talks about the singleton context, but it is naturally also global.

Extensions are now specified to cause a deployment problem if registration of a custom context for a built-in global scope is attempted.

Further, build compatible extensions are now specified to allow registering custom contexts for the same set of scopes as portable extensions. Previously, registering custom contexts for built-in scopes was forbidden, which is too limiting and was never enforced (by the TCK and by implementations).

Fixes #925