### PR TITLE
Fix example of beans.xml for trimmed archive

### DIFF
--- a/spec/src/main/asciidoc/core/packagingdeployment_full.asciidoc
+++ b/spec/src/main/asciidoc/core/packagingdeployment_full.asciidoc
@@ -189,8 +189,9 @@ An explicit bean archive may be marked as 'trimmed' by adding the `<trim />` ele
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_3_0.xsd"
-        version="3.0">
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_1.xsd"
+        version="4.1"
+        bean-discovery-mode="all">
 
     <trim/>
 </beans>


### PR DESCRIPTION
Fixes #938 

The example doesn't declare bean discovery mode hence defaulting to `annotated`.
However, this is a mistake as trimming is only defined for explicit bean archives (mode `all`).

This PR just adds explicit bean discovery mode attribute to the example.