### PR TITLE
Change wording in ATD/BBD#addAnnotatedType() to correspond with how archive trimming is worded.

### DIFF
--- a/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/ScannedClasses.java
+++ b/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/ScannedClasses.java
@@ -20,7 +20,6 @@ package jakarta.enterprise.inject.build.compatible.spi;
 public interface ScannedClasses {
     /**
      * Adds a class with given name to the set of types discovered during type discovery.
-     * The class will therefore be scanned during bean discovery.
      * <p>
      * Adding the same class multiple times, or adding a class that is automatically discovered
      * by the container, leads to non-portable behavior.

--- a/api/src/main/java/jakarta/enterprise/inject/spi/AfterTypeDiscovery.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/AfterTypeDiscovery.java
@@ -70,7 +70,7 @@ public interface AfterTypeDiscovery {
 
     /**
      * <p>
-     * Adds a given {@link AnnotatedType} to the set of types which will be scanned during bean discovery.
+     * Adds a given {@link AnnotatedType} to the set of types discovered during type discovery.
      * </p>
      *
      * <p>
@@ -85,16 +85,16 @@ public interface AfterTypeDiscovery {
      * </p>
      *
      * @param type The {@link AnnotatedType} to add for later scanning
-     * @param id the identifier used to distinguish this AnnotatedType from an other one based on the same underlying type
+     * @param id the identifier used to distinguish this AnnotatedType from another one based on the same underlying type
      * @throws IllegalStateException if called outside of the observer method invocation
      */
     public void addAnnotatedType(AnnotatedType<?> type, String id);
 
     /**
      * <p>
-     * Obtains a new {@link AnnotatedTypeConfigurator} to configure a new {@link AnnotatedType} and add it to the set of types
-     * which will be scanned during bean discovery at the end of the observer invocation. Calling this method multiple times
-     * will return a new AnnotatedTypeConfigurator.
+     * Obtains a new {@link AnnotatedTypeConfigurator} to configure a new {@link AnnotatedType} and add it to the set
+     * of types discovered during type discovery at the end of the observer invocation.
+     * Calling this method multiple times will return a new {@link AnnotatedTypeConfigurator}.
      * </p>
      *
      * <p>
@@ -111,10 +111,10 @@ public interface AfterTypeDiscovery {
      * Each call returns a new AnnotatedTypeConfigurator.
      *
      *
-     * @param <T> annotatated instance type
-     * @param type class used to initialized the type and annotations on the {@link AnnotatedTypeConfigurator}
-     * @param id the identifier used to distinguish this AnnotatedType from an other one based on the same underlying type
-     * @return a non reusable {@link AnnotatedTypeConfigurator} to configure the new AnnotatedType
+     * @param <T> annotated instance type
+     * @param type class used to initialize the type and annotations on the {@link AnnotatedTypeConfigurator}
+     * @param id the identifier used to distinguish this AnnotatedType from another one based on the same underlying type
+     * @return a non-reusable {@link AnnotatedTypeConfigurator} to configure the new AnnotatedType
      * @throws IllegalStateException if called outside of the observer method invocation
      * @since 2.0
      */

--- a/api/src/main/java/jakarta/enterprise/inject/spi/BeforeBeanDiscovery.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/BeforeBeanDiscovery.java
@@ -140,7 +140,7 @@ public interface BeforeBeanDiscovery {
 
     /**
      * <p>
-     * Adds a given {@link AnnotatedType} to the set of types which will be scanned during bean discovery.
+     * Adds a given {@link AnnotatedType} to the set of types discovered during type discovery.
      * </p>
      *
      * <p>
@@ -155,7 +155,7 @@ public interface BeforeBeanDiscovery {
      * </p>
      *
      * @param type The {@link AnnotatedType} to add for later scanning
-     * @param id the identifier used to distinguish this AnnotatedType from an other one based on the same underlying type
+     * @param id the identifier used to distinguish this AnnotatedType from another one based on the same underlying type
      * @throws IllegalStateException if called outside of the observer method invocation
      * @since 1.1
      */
@@ -163,8 +163,8 @@ public interface BeforeBeanDiscovery {
 
     /**
      * <p>
-     * Obtains a new {@link AnnotatedTypeConfigurator} to configure a new {@link AnnotatedType} and
-     * add it to the set of types which will be scanned during bean discovery at the end of the observer invocation
+     * Obtains a new {@link AnnotatedTypeConfigurator} to configure a new {@link AnnotatedType} and add it
+     * to the set of types discovered during type discovery at the end of the observer invocation.
      * </p>
      *
      * <p>
@@ -183,9 +183,9 @@ public interface BeforeBeanDiscovery {
      *
      *
      * @param <T> class type
-     * @param type class used to initialized the type and annotations on the {@link AnnotatedTypeConfigurator}
-     * @param id the identifier used to distinguish this AnnotatedType from an other one based on the same underlying type
-     * @return a non reusable {@link AnnotatedTypeConfigurator} to configure the new AnnotatedType
+     * @param type class used to initialize the type and annotations on the {@link AnnotatedTypeConfigurator}
+     * @param id the identifier used to distinguish this AnnotatedType from another one based on the same underlying type
+     * @return a non-reusable {@link AnnotatedTypeConfigurator} to configure the new AnnotatedType
      * @throws IllegalStateException if called outside of the observer method invocation
      * @since 2.0
      */

--- a/spec/src/main/asciidoc/core/spi_full.asciidoc
+++ b/spec/src/main/asciidoc/core/spi_full.asciidoc
@@ -937,7 +937,7 @@ public interface BeforeBeanDiscovery {
 * `addScope()` declares an annotation type as a scope type.
 * `addStereotype()` declares an annotation type as a stereotype, and specifies its meta-annotations.
 * `addInterceptorBinding()` declares an annotation type as an interceptor binding type, and specifies its meta-annotations.
-* `addAnnotatedType()` adds a given `AnnotatedType` to the set of types which will be scanned during bean discovery, with an optional identifier.
+* `addAnnotatedType()` adds a given `AnnotatedType` to the set of types discovered during type discovery, with an identifier.
 +
 Second version of the method returns a new `AnnotatedTypeConfigurator` as defined in <<annotated_type_configurator>> to easily configure the `AnnotatedType` which will be added at the end of the observer invocation.
 The returned `AnnotatedTypeConfigurator` is initialized with type and annotations of the provided class.
@@ -982,7 +982,7 @@ Alternatives enabled for a bean archive are not included in the list.
 Interceptors enabled for a bean archive are not included in the list.
 * `getDecorators()` returns the ordered list of enabled decorators for the application, sorted by priority in ascending order.
 Decorators enabled for a bean archive are not included in the list.
-* `addAnnotatedType()` adds a given `AnnotatedType` to the set of types which will be scanned during bean discovery, with an identifier.
+* `addAnnotatedType()` adds a given `AnnotatedType` to the set of types discovered during type discovery, with an identifier.
 +
 The second version of the method, returns a new `AnnotatedTypeConfigurator` as defined in <<annotated_type_configurator>> to easily configure the `AnnotatedType` which will be added at the end of observer invocation.
 The returned `AnnotatedTypeConfigurator` is initialized with type and annotations of the provided class.


### PR DESCRIPTION
Fixes #939 

Current wording of bean archive trimming is (emphasis mine):

> If an explicit bean archive contains the <trim/> element in its beans.xml file, types that don’t have either a bean defining annotation (as defined in [Bean defining annotations](https://jakarta.ee/specifications/cdi/4.1/jakarta-cdi-spec-4.1#bean_defining_annotations)) or any scope annotation, **are removed from the set of discovered types**.

This PR suggest a slight change to wording of `BeforeBeanDiscovery/AfterTypeDiscovery#addAnnotatedType` so that it is clearly implied that even added synthetic types are part of the 'set of discovered types' and hence subject to archive trimming.

Note that when it comes to BCE, there is [`ScannedClasses`](https://github.com/jakartaee/cdi/blob/ff86ca5cc3d86c219a65f3dcf22b6b85a56ac214/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/ScannedClasses.java#L14) which already uses this kind of wording:

> Allows adding additional classes to the set of types discovered during type discovery.