### PR TITLE
improve async handlers specification

### DIFF
--- a/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/BuildCompatibleExtension.java
+++ b/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/BuildCompatibleExtension.java
@@ -11,10 +11,8 @@
 package jakarta.enterprise.inject.build.compatible.spi;
 
 /**
- * Build compatible extensions are service providers for this interface, as defined in {@link java.util.ServiceLoader}.
- * This means: they are classes that implement this interface, provide a {@code META-INF/services} file,
- * and satisfy all other service provider constraints. Additionally, build compatible extensions must not be beans
- * and must not be referred to by application code.
+ * Build compatible extensions are service providers for this interface declared in {@code META-INF/services}.
+ * Additionally, build compatible extensions must not be beans and must not be referred to by application code.
  * <p>
  * Build compatible extensions may define arbitrary {@code public}, non-{@code static}, {@code void}-returning methods
  * without type parameters, annotated with one of the extension annotations. Such methods are called extension methods.

--- a/spec/src/main/asciidoc/core/beanmanager_lite.asciidoc
+++ b/spec/src/main/asciidoc/core/beanmanager_lite.asciidoc
@@ -67,7 +67,7 @@ If no qualifier is passed to `Instance.select()`, there is one required qualifie
 When `CDI.current()` is called, `getCDI()` method is called on `jakarta.enterprise.inject.spi.CDIProvider`.
 
 The `CDIProvider` to use may be set by the application or container using the `setCDIProvider()` method.
-If the `setCDIProvider()` has not been called, the service provider with highest priority of the service `jakarta.enterprise.inject.spi.CDIProvider` declared in META-INF/services is used.
+If the `setCDIProvider()` has not been called, the service provider with highest priority of the service `jakarta.enterprise.inject.spi.CDIProvider` declared in `META-INF/services` is used.
 The order of more than one `CDIProvider` with the same priority is undefined.
 If no provider is available an `IllegalStateException` is thrown.
 

--- a/spec/src/main/asciidoc/core/invokers.asciidoc
+++ b/spec/src/main/asciidoc/core/invokers.asciidoc
@@ -237,8 +237,7 @@ public interface AsyncHandler<T> {
 }
 ----
 
-An _async handler_ is a service provider of `jakarta.enterprise.invoke.AsyncHandler`.
-An async handler may not declare a provider method; it must declare a provider constructor.
+An _async handler_ is a service provider of `jakarta.enterprise.invoke.AsyncHandler` declared in `META-INF/services`.
 An async handler must have a direct superinterface type that is a parameterized type whose generic interface is `AsyncHandler` and its sole type argument is a class type, interface type or parameterized type, otherwise deployment problem occurs.
 The erasure of the type argument to `AsyncHandler` is called the _async type_ of the async handler.
 An async handler must be stateless (and therefore thread safe); there are no guarantees about its lifecycle.
@@ -263,7 +262,7 @@ The CDI container must include async handlers for the following return types:
 - `java.util.concurrent.CompletableFuture`
 - `java.util.concurrent.Flow.Publisher`
 
-If the target method matches more than one async handler, by default a deployment problem occurs.
+If two async handlers have the same async type, by default a deployment problem occurs.
 Containers are required to provide implementation-defined means of configuring an async handler that should be used for any given async type.
 If such configuration is present, other async handlers for the given async type are ignored; the target method only matches the configured async handler.
 If the configured async handler does not exist, deployment problem occurs.

--- a/spec/src/main/asciidoc/core/spi_lite.asciidoc
+++ b/spec/src/main/asciidoc/core/spi_lite.asciidoc
@@ -17,7 +17,7 @@ A build compatible extension may integrate with the container during deployment 
 
 === The `BuildCompatibleExtension` interface
 
-A build compatible extension is a service provider of the `jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension` interface, declared in `META-INF/services`.
+A build compatible extension is a service provider of the `jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension` interface declared in `META-INF/services`.
 
 [source, java]
 ----

--- a/spec/src/main/asciidoc/javase/bootstrap_se.asciidoc
+++ b/spec/src/main/asciidoc/javase/bootstrap_se.asciidoc
@@ -14,7 +14,7 @@ SPDX-License-Identifier: Apache-2.0
 In Java SE, the CDI container must be explicitly bootstrapped by the user.
 This is performed by the `SeContainerInitializer` abstract class and its static method `newInstance()`.
 
-`SeContainerInitializer` is a service provider of the service `jakarta.enterprise.inject.se.SeContainerInitializer` declared in META-INF/services.
+`SeContainerInitializer` is a service provider of the service `jakarta.enterprise.inject.se.SeContainerInitializer` declared in `META-INF/services`.
 This class allows a user to configure the CDI container before it is bootstrapped.
 The `SeContainerInitializer.initialize()` method bootstraps the container and returns a `SeContainer` instance.
 


### PR DESCRIPTION
The situation where explicit configuration is needed is now clarified: it is not just when a target method matches multiple async handlers, but when multiple async handlers have the same async type.

Further, this commit makes the wording about service providers consistent across the spec: it's always "service provider declared in `META-INF/services`". This used to make no sense before Java 9, because there was no other way to declare service providers, but it actually saves us now in Java 9+. This is because there are _two_ ways to declare a service provider: in `META-INF/services` or in the module descriptor. We acknowledge that we currently require `META-INF/services` and declaring a service provider in the module descriptor is nonportable. We'll need to get back to it later.

With this, the section on async handlers gets rid of the sentence about the difference between provider method and provider constructor, because that only applies to service providers declared in the module descriptor. Service providers declared in `META-INF/services` always have a provider constructor.