### PR TITLE
allow supporting Kotlin `suspend` functions in async handlers

### DIFF
--- a/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/BuildCompatibleExtension.java
+++ b/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/BuildCompatibleExtension.java
@@ -11,10 +11,8 @@
 package jakarta.enterprise.inject.build.compatible.spi;
 
 /**
- * Build compatible extensions are service providers for this interface, as defined in {@link java.util.ServiceLoader}.
- * This means: they are classes that implement this interface, provide a {@code META-INF/services} file,
- * and satisfy all other service provider constraints. Additionally, build compatible extensions must not be beans
- * and must not be referred to by application code.
+ * Build compatible extensions are service providers for this interface declared in {@code META-INF/services}.
+ * Additionally, build compatible extensions must not be beans and must not be referred to by application code.
  * <p>
  * Build compatible extensions may define arbitrary {@code public}, non-{@code static}, {@code void}-returning methods
  * without type parameters, annotated with one of the extension annotations. Such methods are called extension methods.

--- a/api/src/main/java/jakarta/enterprise/invoke/AsyncHandler.java
+++ b/api/src/main/java/jakarta/enterprise/invoke/AsyncHandler.java
@@ -72,6 +72,25 @@ public interface AsyncHandler<T> {
     T transform(T original, Runnable completion);
 
     /**
+     * Called only on {@link ParameterType @ParameterType} async handlers, after the target
+     * method returns normally. Allows the async handler to detect synchronous completion
+     * of the asynchronous action based on the return value of the target method.
+     * <p>
+     * In some async protocols, the target method may complete synchronously without invoking
+     * the callback that was wrapped by {@link #transform(Object, Runnable) transform()}.
+     * This method should detect such synchronous completion and call {@code completion.run()}.
+     * <p>
+     * The default implementation does nothing. This is the correct behavior for most
+     * {@link ParameterType @ParameterType} async handlers; the only known situation when
+     * this method needs to be implemented is invoking Kotlin {@code suspend} functions.
+     *
+     * @param returnValue the return value of the target method
+     * @param completion the same completion action that was passed to {@code transform()}
+     */
+    default void checkReturnValue(Object returnValue, Runnable completion) {
+    }
+
+    /**
      * If an async handler is annotated {@code @ReturnType}, the target method matches when
      * the erasure of its return type is identical to the async type of the async handler.
      * <p>

--- a/spec/src/main/asciidoc/core/beanmanager_lite.asciidoc
+++ b/spec/src/main/asciidoc/core/beanmanager_lite.asciidoc
@@ -67,7 +67,7 @@ If no qualifier is passed to `Instance.select()`, there is one required qualifie
 When `CDI.current()` is called, `getCDI()` method is called on `jakarta.enterprise.inject.spi.CDIProvider`.
 
 The `CDIProvider` to use may be set by the application or container using the `setCDIProvider()` method.
-If the `setCDIProvider()` has not been called, the service provider with highest priority of the service `jakarta.enterprise.inject.spi.CDIProvider` declared in META-INF/services is used.
+If the `setCDIProvider()` has not been called, the service provider with highest priority of the service `jakarta.enterprise.inject.spi.CDIProvider` declared in `META-INF/services` is used.
 The order of more than one `CDIProvider` with the same priority is undefined.
 If no provider is available an `IllegalStateException` is thrown.
 

--- a/spec/src/main/asciidoc/core/invokers.asciidoc
+++ b/spec/src/main/asciidoc/core/invokers.asciidoc
@@ -237,8 +237,7 @@ public interface AsyncHandler<T> {
 }
 ----
 
-An _async handler_ is a service provider of `jakarta.enterprise.invoke.AsyncHandler`.
-An async handler may not declare a provider method; it must declare a provider constructor.
+An _async handler_ is a service provider of `jakarta.enterprise.invoke.AsyncHandler` declared in `META-INF/services`.
 An async handler must have a direct superinterface type that is a parameterized type whose generic interface is `AsyncHandler` and its sole type argument is a class type, interface type or parameterized type, otherwise deployment problem occurs.
 The erasure of the type argument to `AsyncHandler` is called the _async type_ of the async handler.
 An async handler must be stateless (and therefore thread safe); there are no guarantees about its lifecycle.
@@ -263,7 +262,7 @@ The CDI container must include async handlers for the following return types:
 - `java.util.concurrent.CompletableFuture`
 - `java.util.concurrent.Flow.Publisher`
 
-If the target method matches more than one async handler, by default a deployment problem occurs.
+If two async handlers have the same async type, by default a deployment problem occurs.
 Containers are required to provide implementation-defined means of configuring an async handler that should be used for any given async type.
 If such configuration is present, other async handlers for the given async type are ignored; the target method only matches the configured async handler.
 If the configured async handler does not exist, deployment problem occurs.

--- a/spec/src/main/asciidoc/core/invokers.asciidoc
+++ b/spec/src/main/asciidoc/core/invokers.asciidoc
@@ -234,6 +234,9 @@ Method invokers have special support for asynchronous methods when it comes to d
 ----
 public interface AsyncHandler<T> {
     T transform(T original, Runnable completion);
+
+    default void checkReturnValue(Object returnValue, Runnable completion) {
+    }
 }
 ----
 
@@ -250,7 +253,17 @@ If the target method matches exactly one async handler, the invoker becomes asyn
 An asynchronous invoker calls the `transform()` method of the matching async handler exactly once during `invoke()`.
 If the matching async handler is annotated `@AsyncHandler.ReturnType`, the `transform()` method is called after the target method is called, with the return value of the target method as the `original`, and the result is returned to the caller.
 If the matching async handler is annotated `@AsyncHandler.ParameterType`, the `transform()` method is called before the target method is called, with the given argument value of the async parameter as the `original`, and the result is passed to the target method as the argument value of the async parameter.
+If the matching async handler is annotated `@AsyncHandler.ParameterType`, the `checkReturnValue()` method is called after the target method returns normally, with the return value of the target method as the `returnValue` and the same `completion` that was previously passed to `transform()`.
 The async handler signals completion of the asynchronous action by calling `completion.run()`.
+
+[NOTE]
+====
+There are asynchronous protocols that signal completion either through the return value (in case of synchronous completion) or through the callback (in case of asynchronous completion).
+The `checkReturnValue()` method allows distinguishing this based on the return value.
+
+Vast majority of async handlers do not need to implement `checkReturnValue()`, because completion is signaled exclusively through the callback.
+The only known situation when `checkReturnValue()` needs to be implemented is invoking Kotlin `suspend` functions.
+====
 
 The requirement to destroy instances of `@Dependent` looked up beans is different for asynchronous invokers.
 The instances of `@Dependent` looked up beans are destroyed when the asynchronous action completes, as signalled by the async handler.

--- a/spec/src/main/asciidoc/core/spi_lite.asciidoc
+++ b/spec/src/main/asciidoc/core/spi_lite.asciidoc
@@ -17,7 +17,7 @@ A build compatible extension may integrate with the container during deployment 
 
 === The `BuildCompatibleExtension` interface
 
-A build compatible extension is a service provider of the `jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension` interface, declared in `META-INF/services`.
+A build compatible extension is a service provider of the `jakarta.enterprise.inject.build.compatible.spi.BuildCompatibleExtension` interface declared in `META-INF/services`.
 
 [source, java]
 ----

--- a/spec/src/main/asciidoc/javase/bootstrap_se.asciidoc
+++ b/spec/src/main/asciidoc/javase/bootstrap_se.asciidoc
@@ -14,7 +14,7 @@ SPDX-License-Identifier: Apache-2.0
 In Java SE, the CDI container must be explicitly bootstrapped by the user.
 This is performed by the `SeContainerInitializer` abstract class and its static method `newInstance()`.
 
-`SeContainerInitializer` is a service provider of the service `jakarta.enterprise.inject.se.SeContainerInitializer` declared in META-INF/services.
+`SeContainerInitializer` is a service provider of the service `jakarta.enterprise.inject.se.SeContainerInitializer` declared in `META-INF/services`.
 This class allows a user to configure the CDI container before it is bootstrapped.
 The `SeContainerInitializer.initialize()` method bootstraps the container and returns a `SeContainer` instance.
 


### PR DESCRIPTION
This is a draft for 2 reasons:

1. It includes the commit from #961, just because it's easier.
2. I'm not sure we want to do this. The async handler interface becomes more complex only to be able to accommodate Kotlin `suspend` functions, which is a trade off I'm not sure we're ready to make. Also I'm not terribly fond of the API design. In other words, there are downsides that perhaps outweigh the upside.

I'd be interested to hear your opinions.