### PR TITLE
improve the specification of `SyntheticInjections`

### DIFF
--- a/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/SyntheticBeanCreator.java
+++ b/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/SyntheticBeanCreator.java
@@ -38,6 +38,10 @@ public interface SyntheticBeanCreator<T> {
      * All injectable references looked up from {@code SyntheticInjections} have to previously be registered using
      * {@code SyntheticBeanBuilder.withInjectionPoint()}.
      * <p>
+     * All {@code @Dependent} bean instances created by {@code SyntheticInjections} for this creation function
+     * are dependent objects of the created synthetic bean and so are destroyed when the synthetic bean instance
+     * is destroyed.
+     * <p>
      * If the synthetic bean is {@code @Dependent}, the {@code InjectionPoint} to which it is injected
      * may be obtained from the {@code SyntheticInjections} parameter, if previously registered.
      * <p>

--- a/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/SyntheticBeanDisposer.java
+++ b/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/SyntheticBeanDisposer.java
@@ -37,6 +37,9 @@ public interface SyntheticBeanDisposer<T> {
      * All injectable references looked up from {@code SyntheticInjections} have to previously be registered using
      * {@code SyntheticBeanBuilder.withInjectionPoint()}.
      * <p>
+     * All {@code @Dependent} bean instances created by {@code SyntheticInjections} for this destruction function
+     * are destroyed when the {@code dispose()} invocation completes.
+     * <p>
      * Trying to look up {@code InjectionPoint} from the {@code SyntheticInjections} parameter is invalid.
      * <p>
      * The parameter map contains the same values that were passed to {@code SyntheticBeanBuilder.withParam()}.

--- a/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/SyntheticInjections.java
+++ b/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/SyntheticInjections.java
@@ -19,8 +19,9 @@ import jakarta.enterprise.util.TypeLiteral;
  * A synthetic bean creation/destruction function can look up beans in this container
  * that were previously registered using {@code SyntheticBeanBuilder.withInjectionPoint()}.
  * <p>
- * All {@code @Dependent} bean instances created by {@code SyntheticInjections} are destroyed
- * when the corresponding synthetic bean instance is destroyed.
+ * The synthetic bean creation/destruction functions do <em>not</em> share the instance
+ * of {@code SyntheticInjections} and do <em>not</em> share the injectable references
+ * for registered injection points.
  *
  * @since 5.0
  */


### PR DESCRIPTION
This clarifies that `SyntheticBeanCreator` and `SyntheticBeanDisposer` behave similarly to producer/disposer methods also when it comes to injected `@Dependent` beans.

When a `@Dependent` bean is injected into a producer, it becomes a dependent object of the produced instance and so is destroyed when the produced instance is destroyed. The same occurs here: when a `@Dependent` bean is created by `SyntheticInjections` in the `SyntheticBeanCreator`, it becomes a dependent object of the synthetic bean instance and so is destroyed when the instance is destroyed.

When a `@Dependent` bean is injected into a disposer, it is destroyed when the disposer invocation completes. The same occurs here: when a `@Dependent` bean is created by `SyntheticInjections` in the `SyntheticBeanDisposer`, it is destroyed when the `SyntheticBeanDisposer.dispose()` invocation completes.

Producer and disposer are independent and so don't share injection points. The same occurs here: `SyntheticBeanCreator` and `SyntheticBeanDisposer` don't share `SyntheticInjections` and don't share instances for the same injection points.