### PR TITLE
respecify async handlers

### DIFF
--- a/api/src/main/java/jakarta/enterprise/invoke/AsyncHandler.java
+++ b/api/src/main/java/jakarta/enterprise/invoke/AsyncHandler.java
@@ -10,98 +10,113 @@
 
 package jakarta.enterprise.invoke;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.Flow;
-
 /**
- * Includes logic for determining when an asynchronous action started by an invocation
- * of an asynchronous method completes. Service providers of this interface are called
- * <em>async handlers</em>. For the purpose of method invokers, a method is called
- * <em>asynchronous</em> if it matches an async handler.
+ * Determines when an asynchronous action started by an invocation of an asynchronous method
+ * completes. For the purpose of method invokers, a method is called <em>asynchronous</em> if it matches
+ * exactly one async handler. An <em>async handler</em> is either a {@linkplain ReturnType return type async handler}
+ * or a {@linkplain ParameterType parameter type async handler}. For an asynchronous method, the matching async handler
+ * is called during {@link Invoker#invoke(Object, Object[]) Invoker.invoke()}.
  * <p>
- * An <em>async type</em> of an async handler is the erasure of the type argument
- * to the {@code AsyncHandler} direct superinterface type.
+ * Async handlers must be stateless. No guarantees about their lifecycle are made.
  * <p>
- * An async handler must be annotated either {@link ReturnType} or {@link ParameterType}.
- * This annotation determines how methods are matched and how the async handler is used.
- * <p>
- * The {@link #transform(Object, Runnable) transform()} method of a matching async handler
- * is called exactly once by {@link Invoker#invoke(Object, Object[]) Invoker.invoke()}.
- * It takes an {@code original} asynchronous action and returns a transformation of it.
- * This transformation calls {@code completion.run()} exactly once, when the asynchronous
- * action completes.
- * <p>
- * For example, an async handler for {@link java.util.concurrent.CompletionStage} may look like:
- *
- * <pre>
- * &#064;ReturnType
- * public class CompletionStageAsyncHandler&lt;T&gt; implements AsyncHandler&lt;CompletionStage&lt;T&gt;&gt; {
- *     public CompletionStage&lt;T&gt; transform(CompletionStage&lt;T&gt; original, Runnable completion) {
- *         return original.whenComplete((value, error) -> {
- *             completion.run();
- *         });
- *     }
- * }
- * </pre>
- *
- * The CDI container must provide an async handler for the return types of
+ * The CDI container provides built-in return type async handlers for
  * {@link java.util.concurrent.CompletionStage CompletionStage},
- * {@link java.util.concurrent.CompletableFuture CompletableFuture} and
- * {@link Flow.Publisher Flow.Publisher}.
+ * {@link java.util.concurrent.CompletableFuture CompletableFuture}
+ * and {@link java.util.concurrent.Flow.Publisher Flow.Publisher}.
  *
- * @param <T> the type that represents the asynchronous action
  */
-public interface AsyncHandler<T> {
+public interface AsyncHandler {
     /**
-     * Takes the {@code original} asynchronous action and returns a variant of it, transformed
-     * such that {@code completion.run()} is called on completion. Note that {@code completion.run()}
-     * must be called exactly once.
+     * A <em>return type async handler</em> is a service provider for this interface declared
+     * in {@code META-INF/services}. The <em>async type</em> of a return type async handler is the erasure
+     * of the type argument to the {@code AsyncHandler.ReturnType} direct superinterface type.
      * <p>
-     * It is recommended that {@code completion.run()} is called <em>before</em> completion
-     * is propagated to the caller.
+     * A target method matches a return type async handler when the erasure of the method's return type
+     * is identical to the async type of the async handler.
      *
-     * @param original the original asynchronous action
-     * @param completion action that must be executed when the asynchronous action completes
-     * @return the transformed async action
+     * @see #transform(Object, Runnable)
+     * @param <T> the async type of the handler
      */
-    T transform(T original, Runnable completion);
-
-    /**
-     * If an async handler is annotated {@code @ReturnType}, the target method matches when
-     * the erasure of its return type is identical to the async type of the async handler.
-     * <p>
-     * In such case, the {@code AsyncHandler.transform()} method is called after the target
-     * method returns. The original return value is passed to {@code transform()} as
-     * {@code original} and the return value of {@code transform()} is returned to the caller.
-     * <p>
-     * If an async handler is annotated {@code @ReturnType}, it must not be annotated
-     * {@code @ParameterType}, otherwise deployment problem occurs.
-     */
-    @Target(ElementType.TYPE)
-    @Retention(RetentionPolicy.RUNTIME)
-    @interface ReturnType {
+    interface ReturnType<T> {
+        /**
+         * Called once by {@link Invoker#invoke(Object, Object[]) Invoker.invoke()}, after the target method
+         * returns. When the target method throws an exception synchronously, this method is not called.
+         * <p>
+         * Takes the {@code original} return value and returns a variant of it, transformed such that
+         * {@code completion.run()} is called on completion. Note that {@code completion.run()} must be called
+         * exactly once. The result is returned to the invoker caller instead of the {@code original}.
+         * <p>
+         * It is recommended that {@code completion.run()} is called <em>before</em> completion is propagated
+         * to the caller.
+         *
+         * @param original the original asynchronous return value
+         * @param completion action that must be executed when the asynchronous action completes
+         * @return the transformed asynchronous return value
+         */
+        T transform(T original, Runnable completion);
     }
 
     /**
-     * If an async handler is annotated {@code @ParameterType}, the target method matches when
-     * it declares exactly one parameter whose type's erasure is identical to the async type
-     * of the async handler.
+     * A <em>parameter type async handler</em> is a service provider for this interface declared
+     * in {@code META-INF/services}. An <em>async type</em> of a parameter type async handler is the erasure
+     * of the type argument to the {@code AsyncHandler.ParameterType} direct superinterface type.
      * <p>
-     * In such case, the {@code AsyncHandler.transform()} method is called before the target
-     * method is called. The original argument value is passed to {@code transform()} as
-     * {@code original} and the return value of {@code transform()} is passed as an argument
-     * to the target method.
-     * <p>
-     * If an async handler is annotated {@code @ParameterType}, it must not be annotated
-     * {@code @ReturnType}, otherwise deployment problem occurs.
+     * A target method matches a parameter type async handler when it declares exactly one parameter
+     * whose type's erasure is identical to the async type of the async handler. This parameter is called
+     * the <em>async parameter</em>.
+     *
+     * @see #transformArgument(Object, Runnable)
+     * @see #transformReturnValue(Object, Runnable)
+     * @param <T> the async type of the handler
      */
-    @Target(ElementType.TYPE)
-    @Retention(RetentionPolicy.RUNTIME)
-    @interface ParameterType {
+    interface ParameterType<T> {
+        /**
+         * Called once by {@link Invoker#invoke(Object, Object[]) Invoker.invoke()}, before the target method
+         * is invoked.
+         * <p>
+         * Takes the {@code original} argument value for the async parameter and returns a variant of it,
+         * transformed such that {@code completion.run()} is called on completion. The result is passed to the
+         * target method instead of the {@code original}.
+         * <p>
+         * The net effect of this method and {@link #transformReturnValue(Object, Runnable)} must be that
+         * {@code completion.run()} is called exactly once, after the asynchronous action completes. It is
+         * recommended that {@code completion.run()} is called <em>before</em> completion is propagated to the
+         * caller.
+         *
+         * @param original the original argument value for the async parameter
+         * @param completion action that must be executed when the asynchronous action completes
+         * @return the transformed argument value for the async parameter
+         */
+        T transformArgument(T original, Runnable completion);
+
+        /**
+         * Called once by {@link Invoker#invoke(Object, Object[]) Invoker.invoke()}, after the target method
+         * returns. When the target method throws an exception synchronously, this method is not called.
+         * <p>
+         * Takes the {@code original} return value and returns a variant of it, performing any transformation
+         * necessary such that that {@code completion.run()} is called on completion. The result is returned
+         * to the invoker caller instead of the {@code original}.
+         * <p>
+         * The net effect of this method and {@link #transformArgument(Object, Runnable)} must be that
+         * {@code completion.run()} is called exactly once, after the asynchronous action completes. It is
+         * recommended that {@code completion.run()} is called <em>before</em> completion is propagated to the
+         * caller.
+         * <p>
+         * The default implementation returns {@code original} directly.
+         * <p>
+         * Note that vast majority of parameter type async handlers do <em>not</em> need to implement
+         * this method, because completion is usually signaled solely through the async parameter. This method
+         * only needs to be implemented if the return value may also be used to signal completion.
+         * As of this writing, the only known situation when this occurs is Kotlin {@code suspend} functions,
+         * where synchronous completion is signaled through the return value and asynchronous completion
+         * is signaled through the {@code Continuation} parameter.
+         *
+         * @param original the original return value
+         * @param completion action that must be executed when the asynchronous action completes
+         * @return the transformed return value
+         */
+        default Object transformReturnValue(Object original, Runnable completion) {
+            return original;
+        }
     }
 }

--- a/spec/src/main/asciidoc/core/invokers.asciidoc
+++ b/spec/src/main/asciidoc/core/invokers.asciidoc
@@ -232,38 +232,64 @@ Method invokers have special support for asynchronous methods when it comes to d
 
 [source,java]
 ----
-public interface AsyncHandler<T> {
-    T transform(T original, Runnable completion);
+public interface AsyncHandler {
+    interface ReturnType<T> {
+        T transform(T original, Runnable completion);
+    }
+
+    interface ParameterType<T> {
+        T transformArgument(T original, Runnable completion);
+
+        default Object transformReturnValue(Object original, Runnable completion) {
+            return original;
+        }
+    }
 }
 ----
 
-An _async handler_ is a service provider of `jakarta.enterprise.invoke.AsyncHandler` declared in `META-INF/services`.
-An async handler must have a direct superinterface type that is a parameterized type whose generic interface is `AsyncHandler` and its sole type argument is a class type, interface type or parameterized type, otherwise deployment problem occurs.
-The erasure of the type argument to `AsyncHandler` is called the _async type_ of the async handler.
+An _async handler_ is either a return type async handler or a parameter type async handler.
+
+A _return type async handler_ is a service provider of `jakarta.enterprise.invoke.AsyncHandler.ReturnType` declared in `META-INF/services`.
+A return type async handler must have a direct superinterface type that is a parameterized type whose generic interface is `AsyncHandler.ReturnType` and its sole type argument is a class type, interface type or parameterized type, otherwise definition error occurs.
+The erasure of the type argument to `AsyncHandler.ReturnType` is called the _async type_ of the return type async handler.
+The target method matches a return type async handler if the erasure of the method's return type is identical to the async type of the async handler.
+
+A _parameter type async handler_ is a service provider of `jakarta.enterprise.invoke.AsyncHandler.ParameterType` declared in `META-INF/services`.
+A parameter type async handler must have a direct superinterface type that is a parameterized type whose generic interface is `AsyncHandler.ParameterType` and its sole type argument is a class type, interface type or parameterized type, otherwise definition error occurs.
+The erasure of the type argument to `AsyncHandler.ParameterType` is called the _async type_ of the parameter type async handler.
+The target method matches a parameter type async handler if it declares exactly one parameter whose type's erasure is identical to the async type of the async handler; this parameter is called the _async parameter_.
+
+NOTE: The provider-configuration file in `META-INF/services` must be named `jakarta.enterprise.invoke.AsyncHandler$ReturnType` or `jakarta.enterprise.invoke.AsyncHandler$ParameterType`, because the `ServiceLoader` requires the file name to be a _fully qualified binary name_ of the service.
+
+If an async handler is both a return type async handler and parameter type async handler, definition error occurs.
+
 An async handler must be stateless (and therefore thread safe); there are no guarantees about its lifecycle.
 
-Each async handler must be annotated either `@AsyncHandler.ReturnType` or `@AsyncHandler.ParameterType`, otherwise deployment problem occurs.
-If an async handler is annotated `@AsyncHandler.ReturnType`, the target method matches the async handler if the erasure of its return type is identical to the async type of the async handler.
-If an async handler is annotated `@AsyncHandler.ParameterType`, the target method matches the async handler if it declares exactly one parameter whose type's erasure is identical to the async type of the async handler; this parameter is called an _async parameter_.
-
 If the target method matches exactly one async handler, the invoker becomes asynchronous.
-An asynchronous invoker calls the `transform()` method of the matching async handler exactly once during `invoke()`.
-If the matching async handler is annotated `@AsyncHandler.ReturnType`, the `transform()` method is called after the target method is called, with the return value of the target method as the `original`, and the result is returned to the caller.
-If the matching async handler is annotated `@AsyncHandler.ParameterType`, the `transform()` method is called before the target method is called, with the given argument value of the async parameter as the `original`, and the result is passed to the target method as the argument value of the async parameter.
+
+If the matching async handler is a return type async handler, an asynchronous invoker calls its `transform()` method once during `invoke()`, after the target method returns, with the return value of the target method as the `original`, and returns the result to the caller.
+When the target method throws an exception synchronously, the `transform()` method is not called.
+
+If the matching async handler is a parameter type async handler, an asynchronous invoker:
+
+* calls its `transformArgument()` method once during `invoke()`, before the target method is called, with the given argument value of the async parameter as the `original`, and passes the result to the target method as the argument value of the async parameter;
+* calls its `transformReturnValue()` method once during `invoke()`, after the target method returns, with the return value of the target method as the `original`, and returns the result to the caller.
+When the target method throws an exception synchronously, the `transformReturnValue()` method is not called.
+
 The async handler signals completion of the asynchronous action by calling `completion.run()`.
 
 The requirement to destroy instances of `@Dependent` looked up beans is different for asynchronous invokers.
-The instances of `@Dependent` looked up beans are destroyed when the asynchronous action completes, as signalled by the async handler.
+The instances of `@Dependent` looked up beans are destroyed when the asynchronous action completes, as signaled by the async handler.
 If an asynchronous target method throws synchronously, instances of `@Dependent` looked up beans are destroyed before `invoke()` rethrows the exception; in this case, the async handler is still permitted to call `completion.run()`, but the call must be ignored.
 
-The CDI container must include async handlers for the following return types:
+The CDI container must include return type async handlers for the following types:
 
 - `java.util.concurrent.CompletionStage`
 - `java.util.concurrent.CompletableFuture`
 - `java.util.concurrent.Flow.Publisher`
 
 If two async handlers have the same async type, by default a deployment problem occurs.
-Containers are required to provide implementation-defined means of configuring an async handler that should be used for any given async type.
+Containers are required to provide an implementation-defined means of configuring the async handler that should be used for a particular async type.
 If such configuration is present, other async handlers for the given async type are ignored; the target method only matches the configured async handler.
-If the configured async handler does not exist, deployment problem occurs.
-It is possible to configure a custom async handler for the built-in return types listed above.
+If the configured async handler does not exist or its async type is different from the configured one, deployment problem occurs.
+It is possible to configure a custom async handler for the built-in types listed above.


### PR DESCRIPTION
The API is quite different now: instead of annotations to specify whether a return type or parameter type should be inspected, there are nested interfaces in `AsyncHandler` that need to be implemented.

The `AsyncHandler.ReturnType` is the same as previous `AsyncHandler`, but `AsyncHandler.ParameterType` is more advanced and allows inspecting the return value for cases (like Kotlin `suspend` functions) that use two ways of signaling completion: return value in case of synchronous completion and parameter in case of asynchronous completion.