### PR TITLE
Tighten how @AutoClose can be applied; enforce validate when possible

### DIFF
--- a/api/src/main/java/jakarta/enterprise/context/AutoClose.java
+++ b/api/src/main/java/jakarta/enterprise/context/AutoClose.java
@@ -25,8 +25,18 @@ import jakarta.enterprise.util.AnnotationLiteral;
  * Marks the annotated bean as auto-closeable. May be applied to a bean class,
  * producer method or field or {@linkplain jakarta.enterprise.inject.Stereotype stereotype}.
  * <p>
- * Auto-closeable beans may implement the {@link AutoCloseable} interface. If they do,
- * the {@link AutoCloseable#close()} method is called during bean destruction.
+ * For an auto-closeable managed bean, the bean class must be assignable to {@link AutoCloseable}.
+ * For an auto-closeable producer method, the return type of the method must be assignable to
+ * {@link AutoCloseable}.
+ * For an auto-closeable producer field, the type of the field must be assignable to
+ * {@link AutoCloseable}.
+ * These requirements apply regardless of whether the bean is auto-closeable due to a direct
+ * {@code @AutoClose} annotation or due to a {@linkplain jakarta.enterprise.inject.Stereotype stereotype}.
+ * If these requirements are not satisfied, the container automatically detects
+ * the problem and treats it as a definition error.
+ * <p>
+ * During bean destruction, the {@link AutoCloseable#close()} method is called on
+ * the contextual instance.
  * Note that bean destruction ({@link Contextual#destroy(Object, CreationalContext)})
  * may not throw, so exceptions thrown by {@link AutoCloseable#close()} are swallowed.
  *

--- a/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/SyntheticBeanBuilder.java
+++ b/api/src/main/java/jakarta/enterprise/inject/build/compatible/spi/SyntheticBeanBuilder.java
@@ -175,6 +175,9 @@ public interface SyntheticBeanBuilder<T> {
      * Marks this synthetic bean as {@linkplain jakarta.enterprise.context.AutoClose auto-closeable} if desired.
      * <p>
      * If not called, this synthetic bean will not be auto-closeable.
+     * <p>
+     * If this synthetic bean is marked as auto-closeable and its implementation class is not assignable to
+     * {@link AutoCloseable}, the synthetic bean registration will fail.
      *
      * @param isAutoClose whether this synthetic bean should be auto-closeable
      * @return this {@code SyntheticBeanBuilder}

--- a/api/src/main/java/jakarta/enterprise/inject/spi/Bean.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/Bean.java
@@ -46,10 +46,18 @@ public interface Bean<T> extends Contextual<T>, BeanAttributes<T> {
      *         // log an error or handle the exception in some other way
      *         // bean destruction is not allowed to throw an exception
      *     }
+     * } else if (isAutoClose()) {
+     *     // log an error: auto-closeable bean instance does not implement AutoCloseable
      * }
      *
      * creationalContext.release();
      * }</pre>
+     *
+     * For container-managed beans (class-based and producer-based), the container validates at initialization
+     * time that the statically-known type is assignable to {@link AutoCloseable}, so the {@code instanceof}
+     * check always succeeds. For custom {@code Bean} implementations registered via portable extensions,
+     * the check serves as a defensive guard; if it fails, the container logs an error and skips
+     * the {@code close()} call.
      */
     @Override
     public void destroy(T instance, CreationalContext<T> creationalContext);

--- a/api/src/main/java/jakarta/enterprise/inject/spi/Producer.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/Producer.java
@@ -57,14 +57,12 @@ public interface Producer<T> {
      * </p>
      * <p>
      * If the {@code Producer} represents a managed bean, then this operation does only one thing:
-     * if the bean is auto-closeable and the class of the contextual instance implements {@link AutoCloseable},
-     * {@code close()} is called on the instance.
+     * if the bean is auto-closeable, {@code close()} is called on the instance.
      * </p>
      * <p>
      * If the {@code Producer} represents a producer field or method, this calls the disposer method, if any, on a contextual
      * instance of the bean that declares the disposer method or performs any additional required cleanup, if any, to destroy
-     * state associated with a resource. Then, if the bean is auto-closeable and the class of the contextual instance
-     * implements {@link AutoCloseable}, {@code close()} is called on the instance.
+     * state associated with a resource. Then, if the bean is auto-closeable, {@code close()} is called on the instance.
      * </p>
      *
      * @param instance The instance to dispose

--- a/api/src/main/java/jakarta/enterprise/inject/spi/configurator/BeanAttributesConfigurator.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/configurator/BeanAttributesConfigurator.java
@@ -207,6 +207,11 @@ public interface BeanAttributesConfigurator<T> {
     /**
      * Change the auto-closeable status of the configured bean.
      * By default, the configured bean is not auto-closeable.
+     * <p>
+     * Since the actual class of the contextual instance cannot always be determined statically for beans
+     * configured via portable extensions, no definition error is raised. Instead, if the contextual instance
+     * does not implement {@link AutoCloseable} at destruction time, the container logs an error and skips
+     * the {@code close()} call.
      *
      * @param value value for auto-closeable property
      * @return self

--- a/api/src/main/java/jakarta/enterprise/inject/spi/configurator/BeanConfigurator.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/configurator/BeanConfigurator.java
@@ -356,6 +356,11 @@ public interface BeanConfigurator<T> {
     /**
      * Change the auto-closeable status of the configured bean.
      * By default, the configured bean is not auto-closeable.
+     * <p>
+     * Since the actual class of the contextual instance cannot always be determined statically for beans
+     * configured via portable extensions, no definition error is raised. Instead, if the contextual instance
+     * does not implement {@link AutoCloseable} at destruction time, the container logs an error and skips
+     * the {@code close()} call.
      *
      * @param value value for auto-closeable property
      * @return self

--- a/spec/src/main/asciidoc/core/definition.asciidoc
+++ b/spec/src/main/asciidoc/core/definition.asciidoc
@@ -772,8 +772,17 @@ If a bean of any other pseudo-scope is eagerly initialized, non-portable behavio
 
 A bean class of a managed bean, a producer method and a producer field may be annotated `@AutoClose`.
 This annotation marks the bean as _auto-closeable_.
+A bean that has a stereotype which declares `@AutoClose` is also auto-closeable (see <<auto_close_stereotype>>).
 
-If the class of a contextual instance of an auto-closeable bean implements the `java.lang.AutoCloseable` interface, the `close()` method is called on the instance during destruction.
+The statically-known type of an auto-closeable bean must be assignable to the `java.lang.AutoCloseable` interface:
+
+* For an auto-closeable managed bean, the bean class must be assignable to `AutoCloseable`.
+* For an auto-closeable producer method, the return type of the producer method must be assignable to `AutoCloseable`.
+* For an auto-closeable producer field, the type of the producer field must be assignable to `AutoCloseable`.
+
+If an auto-closeable bean does not satisfy these requirements, the container automatically detects the problem and treats it as a definition error.
+
+During destruction of an auto-closeable bean, the `close()` method is called on the contextual instance.
 See <<managed_bean_lifecycle>>, <<producer_method_lifecycle>> and <<producer_field_lifecycle>> for details.
 
 [[stereotypes]]

--- a/spec/src/main/asciidoc/core/injectionandresolution.asciidoc
+++ b/spec/src/main/asciidoc/core/injectionandresolution.asciidoc
@@ -428,7 +428,7 @@ The container must ensure that:
 
 ==== Destruction of dependent objects
 
-When the container destroys an instance of a bean, the container destroys all dependent objects, as defined in <<dependent_destruction>>, after the `@PreDestroy` callback or disposer method completes and after the possible `AutoCloseable.close()` call returns.
+When the container destroys an instance of a bean, the container destroys all dependent objects, as defined in <<dependent_destruction>>, after the `@PreDestroy` callback or disposer method completes and after the `AutoCloseable.close()` call, if any, returns.
 
 [[producer_or_disposer_methods_invocation]]
 

--- a/spec/src/main/asciidoc/core/lifecycle.asciidoc
+++ b/spec/src/main/asciidoc/core/lifecycle.asciidoc
@@ -122,7 +122,7 @@ The actual mechanics of bean creation and destruction varies according to what k
 When the `create()` method of the `Bean` object that represents a managed bean is called, the container obtains an instance of the bean, calling the bean constructor as defined by <<instantiation>>, and performing dependency injection as defined in <<fields_initializer_methods>>.
 
 When the `destroy()` method is called, the container destroys the instance.
-Then, if the managed bean is auto-closeable and the class of the contextual instance implements `AutoCloseable`, the `close()` method is called on the instance.
+Then, if the managed bean is auto-closeable, the `close()` method is called on the contextual instance.
 Finally, the container destroys dependent objects, as defined in <<dependent_objects_destruction>>.
 
 
@@ -139,7 +139,7 @@ If the producer method returns a null value and the producer method bean has the
 Otherwise, if the producer method returns a null value, and the scope of the producer method is not `@Dependent`, the `create()` method throws an `IllegalProductException`.
 
 When the `destroy()` method is called, and if there is a disposer method for this producer method, the container must invoke the disposer method as defined by <<producer_or_disposer_methods_invocation>>, passing the instance given to `destroy()` to the disposed parameter.
-Then, if the producer method bean is auto-closeable and the class of the contextual instance implements `AutoCloseable`, the `close()` method is called on the instance.
+Then, if the producer method bean is auto-closeable, the `close()` method is called on the contextual instance.
 Finally, the container destroys dependent objects, as defined in <<dependent_objects_destruction>>.
 
 [[producer_field_lifecycle]]
@@ -154,5 +154,5 @@ If the producer field contains a null value and the producer field bean has the 
 Otherwise, if the producer field contains a null value, and the scope of the producer field is not `@Dependent`, the `create()` method throws an `IllegalProductException`.
 
 When the `destroy()` method is called, and if there is a disposer method for this producer field, the container must invoke the disposer method as defined by <<producer_or_disposer_methods_invocation>>, passing the instance given to `destroy()` to the disposed parameter.
-Then, if the producer field bean is auto-closeable and the class of the contextual instance implements `AutoCloseable`, the `close()` method is called on the instance.
+Then, if the producer field bean is auto-closeable, the `close()` method is called on the contextual instance.
 

--- a/spec/src/main/asciidoc/core/spi_full.asciidoc
+++ b/spec/src/main/asciidoc/core/spi_full.asciidoc
@@ -188,7 +188,7 @@ For a `Producer` that represents a managed bean:
 
 * `produce()` calls the constructor annotated `@Inject` if it exists, or the constructor with no parameters otherwise, as defined in <<instantiation>>, and returns the resulting instance. If the bean has interceptors or decorators, `produce()` is responsible for building the interceptors and decorators of the instance.
 The instance returned by `produce()` may be a proxy.
-* `dispose()` only does one thing: if the bean is auto-closeable and the class of the contextual instance of the bean implements `AutoCloseable`, the `close()` method is called on the instance.
+* `dispose()` only does one thing: if the bean is auto-closeable, the `close()` method is called on the contextual instance.
 * `getInjectionPoints()` returns the set of `InjectionPoint` objects representing all injected fields, bean constructor parameters and initializer method parameters.
 
 
@@ -196,7 +196,7 @@ For a `Producer` that represents a producer method or field:
 
 * `produce()` calls the producer method on, or accesses the producer field of, a contextual instance of the bean that declares the producer method, as defined in <<producer_or_disposer_methods_invocation>>.
 * `dispose()` calls the disposer method, if any, on a contextual instance of the bean that declares the disposer method, as defined in <<producer_or_disposer_methods_invocation>>, or performs any additional required cleanup, if any, to destroy state associated with a resource.
-Then, if the bean is auto-closeable and the class of the contextual instance of the bean implements `AutoCloseable`, the `close()` method is called on the instance.
+Then, if the bean is auto-closeable, the `close()` method is called on the contextual instance.
 * `getInjectionPoints()` returns the set of `InjectionPoint` objects representing all parameters of the producer method.
 
 
@@ -1080,6 +1080,8 @@ It can be done from an existing `BeanAttributes`  or by reading metadata on a gi
 * Set a callback to destroy a bean instance with `destroyWith()` or `disposeWith()` method.
 
 If a `BeanConfigurator` has no scope specified, the default scope rules, defined in <<default_scope>>, apply.
+
+If a bean configured via `BeanConfigurator` is marked as auto-closeable but the contextual instance does not implement `AutoCloseable` at destruction time, the container must log an error message; since destroying an instance is not permitted to throw an exception, the `close()` call is skipped.
 
 [[observer_method_configurator]]
 

--- a/spec/src/main/asciidoc/core/spi_lite.asciidoc
+++ b/spec/src/main/asciidoc/core/spi_lite.asciidoc
@@ -359,6 +359,9 @@ The `SyntheticBeanBuilder` and `SyntheticObserverBuilder` interfaces are used to
 * injection points (only `SyntheticBeanBuilder`);
 * a string-keyed parameter map.
 
+If a synthetic bean is marked as auto-closeable, its implementation class must be assignable to `AutoCloseable`.
+If this requirement is not satisfied, the container automatically detects the problem and treats it as a definition error.
+
 The container creates an instance of the bean creation/destruction function or observer notification function whenever it needs to create an instance of the bean, destroy the instance of the bean, or notify the observer.
 When invoking the bean creation/destruction function or observer notification function, the container passes the parameter map to it.
 When invoking the bean creation/destruction function, the container also passes an object that allows obtaining an injectable reference for each defined injection point.


### PR DESCRIPTION
Fixes #968 

I am not saying this should be the final state; I was simply brooding about it some more and ended up drafting this, so I thought I might as well share :)
CC @Ladicek @mkouba 

Specifically, this PR mandates that:
* Class-based beans must be assignable to `AutoCloseable`
* Producer return/field type must be assignable to `AutoCloseable`
* Implementation class of a synthetic BCE bean must be assignable to `AutoCloseable`

Otherwise, it is considered a definition error.
(n case of BCE this is defined as failed bean registration but IIRC that leads to `DefinitionException` anyway.

For synth. beans registered via PE, the spec only mentions the need to log the fact that the bean doesn't meet the expectations as we cannot do more. As it stands, we are only really able to figure this out at runtime when we attempt to destroy that given bean.