### PR TITLE
improve wording in "Built-in qualifier types"

### DIFF
--- a/spec/src/main/asciidoc/core/definition.asciidoc
+++ b/spec/src/main/asciidoc/core/definition.asciidoc
@@ -229,7 +229,7 @@ In {cdi_full} environment, qualifier types are also used to bind decorators to b
 
 ==== Built-in qualifier types
 
-Three standard qualifier types are defined in the package `jakarta.enterprise.inject`. In addition, the built-in qualifier type `@Named` is defined by the package `jakarta.inject`.
+The standard qualifier types `@Any` and `@Default` are defined in the package `jakarta.enterprise.inject`. In addition, the built-in qualifier type `@Named` is defined in the package `jakarta.inject`.
 
 Every bean has the built-in qualifier `@Any`, even if it does not explicitly declare this qualifier.
 


### PR DESCRIPTION
This chapter used to say that "three" qualifier types are defined in `jakarta.enterprise.inject`. This was true before CDI 4.0, because at that time, the chapter talked about `@Any`, `@Default` and `@New` (and `@Named`). However, there were two more qualifiers defined in that package (`@Intercepted` and `@Decorated`), so it wasn't strictly true, and it is even less true after `@New` was removed. This commit improves the wording somewhat.