### PR TITLE
respecify wildcard type arguments for `Event` and `Instance`

### DIFF
--- a/api/src/main/java/jakarta/enterprise/event/Event.java
+++ b/api/src/main/java/jakarta/enterprise/event/Event.java
@@ -73,7 +73,8 @@ import jakarta.enterprise.util.TypeLiteral;
  * </p>
  *
  * <ul>
- * <li>the <em>specified type</em> is the type parameter specified at the injection point, and</li>
+ * <li>the <em>specified type</em> is the type argument specified at the injection point, or the type argument's
+ * lower bound if the type argument is a wildcard, and</li>
  * <li>the <em>specified qualifiers</em> are the qualifiers specified at the injection point.</li>
  * </ul>
  *

--- a/api/src/main/java/jakarta/enterprise/inject/Instance.java
+++ b/api/src/main/java/jakarta/enterprise/inject/Instance.java
@@ -73,7 +73,8 @@ import jakarta.inject.Provider;
  * </p>
  *
  * <ul>
- * <li>the <em>required type</em> is the type parameter specified at the injection point, and</li>
+ * <li>the <em>required type</em> is the type argument specified at the injection point, or the type argument's
+ * upper bound if the type argument is a wildcard, and</li>
  * <li>the <em>required qualifiers</em> are the qualifiers specified at the injection point.</li>
  * </ul>
  *

--- a/spec/src/main/asciidoc/core/events.asciidoc
+++ b/spec/src/main/asciidoc/core/events.asciidoc
@@ -142,7 +142,7 @@ public interface Event<T> {
 
 For an injected `Event`:
 
-* the _specified type_ is the type parameter specified at the injection point, and
+* the _specified type_ is the type argument specified at the injection point, or the type argument's lower bound if the type argument is a wildcard, and
 * the _specified qualifiers_ are the qualifiers specified at the injection point.
 
 
@@ -167,9 +167,7 @@ Event<AdminLoggedInEvent> admin = any.select(
 
 If the specified type contains a type variable, an `IllegalArgumentException` is thrown.
 
-The specified type must not be a wildcard type.
-If an injected `Event` has a specified type that is a wildcard type, the container treats it as a definition error.
-If a programmatically obtained `Event` has a specified type that is a wildcard type, non-portable behavior results.
+If the application attempts to programmatically obtain an `Event` whose specified type is a wildcard without lower bound, an `IllegalArgumentException` is thrown.
 
 If two instances of the same non repeating qualifier type are passed to `select()`, an `IllegalArgumentException` is thrown.
 
@@ -203,8 +201,13 @@ The container must provide a built-in bean with:
 * no bean name, and
 * an implementation provided automatically by the container.
 
+If an injection point of
 
-If an injection point of raw type `Event` is defined, the container automatically detects the problem and treats it as a definition error.
+* raw type `Event`, or
+* type `Event<?>`, or
+* type `Event<? extends X>`, for any type `X`,
+
+is defined, the container automatically detects the problem and treats it as a definition error.
 
 [[observer_resolution]]
 

--- a/spec/src/main/asciidoc/core/events.asciidoc
+++ b/spec/src/main/asciidoc/core/events.asciidoc
@@ -195,8 +195,8 @@ If the runtime type of the event object is assignable to the type of a container
 
 The container must provide a built-in bean with:
 
-* `Event<X>` in its set of bean types, for every Java type `X` that does not contain a type variable,
-* every event qualifier type in its set of qualifier types,
+* bean type `Event<X>`, where `X` is a type variable without bounds,
+* qualifier `@Default`,
 * scope `@Dependent`,
 * no bean name, and
 * an implementation provided automatically by the container.

--- a/spec/src/main/asciidoc/core/injectionandresolution.asciidoc
+++ b/spec/src/main/asciidoc/core/injectionandresolution.asciidoc
@@ -794,13 +794,13 @@ The `close()` method delegates to the aforementioned `destroy()` method.
 
 ==== The built-in `Instance`
 
-The container must provide a built-in bean that:
+The container must provide a built-in bean with:
 
-* is eligible for injection to any injection point with required type `Instance<X>` or `Provider<X>`, for any legal bean type `X`,
-* has any qualifiers
-* has scope `@Dependent`,
-* has no bean name, and
-* has an implementation provided automatically by the container.
+* `Instance<X>` and `Provider<X>` for every legal bean type `X` in its set of bean types,
+* every qualifier type in its set of qualifier types,
+* scope `@Dependent`,
+* no bean name, and
+* an implementation provided automatically by the container.
 
 [[annotationliteral_typeliteral]]
 

--- a/spec/src/main/asciidoc/core/injectionandresolution.asciidoc
+++ b/spec/src/main/asciidoc/core/injectionandresolution.asciidoc
@@ -677,7 +677,7 @@ public interface Instance<T> extends Iterable<T>, Provider<T> {
 
 For an injected `Instance`:
 
-* the _required type_ is the type parameter specified at the injection point, and
+* the _required type_ is the type argument specified at the injection point, or the type argument's upper bound if the type argument is a wildcard, and
 * the _required qualifiers_ are the qualifiers specified at the injection point.
 
 
@@ -700,12 +700,15 @@ Instance<AsynchronousPaymentProcessor> async = anyPaymentProcessor.select(
             AsynchronousPaymentProcessor.class, new AsynchronousQualifier() );
 ----
 
-The required type must not be a wildcard type.
-If an injected `Instance` has a required type that is either a wildcard type or an `Event` whose specified type is a wildcard type, the container treats it as a definition error.
-If a programmatically obtained `Instance` has a required type that is a wildcard type, non-portable behavior results.
+If an injection point of
 
+* raw type `Instance`, or
+* type `Instance<? super X>`, for any type `X`, or
+* type `Instance<X>` or `Instance<? extends X>`, where `X` is a type for which an injection point may not exist, as specified in <<builtin_event>>,
 
-If an injection point of raw type `Instance` is defined, the container automatically detects the problem and treats it as a definition error.
+is defined, the container automatically detects the problem and treats it as a definition error.
+
+If the application attempts to programmatically obtain an `Instance` whose required type is a wildcard with lower bound, an `IllegalArgumentException` is thrown.
 
 If two instances of the same non repeating qualifier type are passed to `select()`, an `IllegalArgumentException` is thrown.
 

--- a/spec/src/main/asciidoc/core/injectionandresolution.asciidoc
+++ b/spec/src/main/asciidoc/core/injectionandresolution.asciidoc
@@ -125,6 +125,12 @@ Parameterized and raw types are considered to match if they are identical or if 
 * The bean has all the required qualifiers.
 If no required qualifiers were explicitly specified, the container assumes the required qualifier `@Default`. A bean has a required qualifier if it has a qualifier with (a) the same type and (b) the same annotation member value for each member which is not annotated `@jakarta.enterprise.util.Nonbinding`.
 
+For the built-in beans defined in <<builtin_instance>> and <<builtin_event>>, the rules above do not apply.
+Instead:
+
+* The built-in bean for `Instance` is assignable to all injection points with required type `Instance<X>` or `Provider<X>`, where `X` is a legal bean type, regardless of required qualifiers.
+* The built-in bean for `Event` is assignable to all injection points with required type `Event<X>`, where `X` is a type that does not contain a type variable, regardless of required qualifiers.
+
 A bean is eligible for injection to a certain injection point if:
 
 * it is available for injection in the module that contains the class that declares the injection point, and
@@ -796,8 +802,8 @@ The `close()` method delegates to the aforementioned `destroy()` method.
 
 The container must provide a built-in bean with:
 
-* `Instance<X>` and `Provider<X>` for every legal bean type `X` in its set of bean types,
-* every qualifier type in its set of qualifier types,
+* bean types `Instance<X>` and `Provider<X>`, where `X` is a type variable without bounds,
+* qualifier `@Default`,
 * scope `@Dependent`,
 * no bean name, and
 * an implementation provided automatically by the container.


### PR DESCRIPTION
The type parameter of `Event` is naturally contravariant, so injecting `Event<? super FooBar>` is meaningful. Injecting `Event<?>` or `Event<? extends FooBar>` is meaningless.

The type parameter of `Instance` is genuinely invariant (even though some might claim it should be treated as covariant), so injecting `Instance<? extends|super FooBar>` is meaningless.

This commit adjusts the specification so that only meaningful wildcards are allowed. It uses a different approach than before, where extra rules were added. These additions are removed and instead, the existing rules that prohibit injecting raw `Event` / `Instance`, are extended so that injecting these types with meaningless wildcard arguments is prohibited as well.

Further, the only meaningful wildcard (`Event<? super FooBar>`) gets special treatment: the specified type is the wildcard's bound. Also, looking up `Event<? extends FooBar>` throws `IllegalArgumentException`, whereas previously, this was just non-portable behavior.