### PR TITLE
Fix race condition in calculating configuredProvider in CDI.current

### DIFF
--- a/api/src/main/java/jakarta/enterprise/inject/spi/CDI.java
+++ b/api/src/main/java/jakarta/enterprise/inject/spi/CDI.java
@@ -85,7 +85,6 @@ public abstract class CDI<T> implements Instance<T> {
                 throw e;
             }
         }
-        configuredProvider = null;
         // Discover providers and cache
         if (discoveredProviders == null) {
             synchronized (lock) {


### PR DESCRIPTION
Moves the lock acquisition out to and around where configuredProvider is set/reset.

Since the lock is acquired unconditionally, change the double checking of discoveredProviders being null to a single check since it's inside the syncronized section now.

Fixes #994