### PR TITLE
clarify wildcards in the bean assignability rules

### DIFF
--- a/spec/src/main/asciidoc/core/injectionandresolution.asciidoc
+++ b/spec/src/main/asciidoc/core/injectionandresolution.asciidoc
@@ -128,8 +128,8 @@ If no required qualifiers were explicitly specified, the container assumes the r
 For the built-in beans defined in <<builtin_instance>> and <<builtin_event>>, the rules above do not apply.
 Instead:
 
-* The built-in bean for `Instance` is assignable to all injection points with required type `Instance<X>` or `Provider<X>`, where `X` is a legal bean type, regardless of required qualifiers.
-* The built-in bean for `Event` is assignable to all injection points with required type `Event<X>`, where `X` is a type that does not contain a type variable, regardless of required qualifiers.
+* The built-in bean for `Instance` is assignable to all injection points with required type `Instance<X>`, `Instance<? extends X>`, `Provider<X>` or `Provider<? extends X>`, where `X` is a legal bean type, regardless of required qualifiers.
+* The built-in bean for `Event` is assignable to all injection points with required type `Event<X>` or `Event<? super X>`, where `X` is a type that does not contain a type variable, regardless of required qualifiers.
 
 A bean is eligible for injection to a certain injection point if:
 


### PR DESCRIPTION
Per the JLS, wildcards are not really types, so the special bean assignability rules for built-in beans `Instance` and `Event` must mention them explicitly.