### PR TITLE
Cdi 5.0 final review fixes

### DIFF
--- a/api/javadoc-pom.xml
+++ b/api/javadoc-pom.xml
@@ -92,7 +92,7 @@
                     </header>
                     <bottom><![CDATA[
 Comments to: <a href="mailto:cdi-dev@eclipse.org">cdi-dev@eclipse.org</a>.<br>
-Copyright &#169; 2018,2024 Eclipse Foundation.<br>
+Copyright &#169; 2018,2026 Eclipse Foundation.<br>
 Use is subject to <a href="{@docRoot}/doc-files/speclicense.html" target="_top">license terms</a>.]]>
                     </bottom>
                     <sourcepath>target/sources-dependency</sourcepath>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -335,7 +335,7 @@
 					</header>
 					<bottom><![CDATA[
 Comments to: <a href="mailto:cdi-dev@eclipse.org">cdi-dev@eclipse.org</a>.<br>
-Copyright &#169; 2018,2023 Eclipse Foundation.<br>
+Copyright &#169; 2018,2026 Eclipse Foundation.<br>
 Use is subject to <a href="{@docRoot}/doc-files/speclicense.html" target="_top">license terms</a>.]]>
 					</bottom>
 				</configuration>

--- a/api/src/main/javadoc/doc-files/speclicense.html
+++ b/api/src/main/javadoc/doc-files/speclicense.html
@@ -1,72 +1,33 @@
 <html>
 <head>
-  <title>Eclipse Foundation Specification License - v1.0</title>
+  <title>Eclipse Foundation Specification License - v2.0</title>
 </head>
 <body>
-<h1>Eclipse Foundation Specification License - v1.0</h1>
-<p>By using and/or copying this document, or the Eclipse Foundation
-  document from which this statement is linked, you (the licensee) agree
-  that you have read, understood, and will comply with the following
-  terms and conditions:</p>
-
-<p>Permission to copy, and distribute the contents of this document, or
-  the Eclipse Foundation document from which this statement is linked, in
-  any medium for any purpose and without fee or royalty is hereby
-  granted, provided that you include the following on ALL copies of the
-  document, or portions thereof, that you use:</p>
-
+<h1>Eclipse Foundation Specification License - v2.0</h1>
+<p>This license (the &ldquo;License&rdquo;) governs the use, modification and distribution of a specification generated pursuant to the Eclipse Foundation Specification Process.</p>
+<p>By using the file or document that incorporates this License (the &ldquo;Document&rdquo;), you (the licensee) agree that you have read, understood, and will comply with the following terms and conditions.</p>
+<p>Permission to copy and distribute the contents of the Document, in any medium for any purpose, and without fee or royalty is hereby granted, provided that you include the following on ALL copies of the Document that you copy or distribute:</p>
 <ul>
-  <li> link or URL to the original Eclipse Foundation document.</li>
-  <li>All existing copyright notices, or if one does not exist, a notice
-    (hypertext is preferred, but a textual representation is permitted)
-    of the form: &quot;Copyright &copy; [$date-of-document]
-    &ldquo;Eclipse Foundation, Inc. &lt;&lt;url to this license&gt;&gt;
-    &quot;
-  </li>
+<li>
+<p>link or URL to the Document</p>
+</li>
+<li>
+<p>All existing copyright notices, or if one does not exist, a notice (hypertext is preferred, but a textual representation is permitted) of the form: "Copyright &copy; [date-of-document] Eclipse Foundation AISBL [URL to this license] This document includes material copied from [title and URL of the Eclipse Foundation specification document]."</p>
+</li>
 </ul>
-
-<p>Inclusion of the full text of this NOTICE must be provided. We
-  request that authorship attribution be provided in any software,
-  documents, or other items or products that you create pursuant to the
-  implementation of the contents of this document, or any portion
-  thereof.</p>
-
-<p>No right to create modifications or derivatives of Eclipse Foundation
-  documents is granted pursuant to this license, except anyone may
-  prepare and distribute derivative works and portions of this document
-  in software that implements the specification, in supporting materials
-  accompanying such software, and in documentation of such software,
-  PROVIDED that all such works include the notice below. HOWEVER, the
-  publication of derivative works of this document for use as a technical
-  specification is expressly prohibited.</p>
-
-<p>The notice is:</p>
-
-<p>&quot;Copyright &copy; 2018 Eclipse Foundation. This software or
-  document includes material copied from or derived from [title and URI
-  of the Eclipse Foundation specification document].&quot;</p>
-
+<p>In addition to the license granted above, you are granted the  right to create modifications or derivatives of the Document:</p>
+<ul>
+<li>
+<p>in software that implements the Document, in supporting materials accompanying such software, and in documentation of such software (collectively the &ldquo;Works&rdquo;), such  Works to be made available under terms of your choice  PROVIDED that all such Works include a notice of the form: &ldquo;This [software/document (choose as applicable)] includes material derived from [title and URL of the Eclipse Foundation specification document].&rdquo;; and</p>
+</li>
+<li>
+<p>in materials that demonstrate or describe conformance with the Document PROVIDED that all such materials include a notice of the form: &ldquo;This material demonstrates conformance with the [title and URL of the Eclipse Foundation specification document].&rdquo;</p>
+</li>
+</ul>
+<p>NOTWITHSTANDING THE FOREGOING, the creation or publication of derivative works of the Document or portions of the Document for use as a specification or standard is expressly prohibited.</p>
 <h2>Disclaimers</h2>
-
-<p>THIS DOCUMENT IS PROVIDED &quot;AS IS,&quot; AND THE COPYRIGHT
-  HOLDERS AND THE ECLIPSE FOUNDATION MAKE NO REPRESENTATIONS OR
-  WARRANTIES, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
-  WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE,
-  NON-INFRINGEMENT, OR TITLE; THAT THE CONTENTS OF THE DOCUMENT ARE
-  SUITABLE FOR ANY PURPOSE; NOR THAT THE IMPLEMENTATION OF SUCH CONTENTS
-  WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR
-  OTHER RIGHTS.</p>
-
-<p>THE COPYRIGHT HOLDERS AND THE ECLIPSE FOUNDATION WILL NOT BE LIABLE
-  FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT
-  OF ANY USE OF THE DOCUMENT OR THE PERFORMANCE OR IMPLEMENTATION OF THE
-  CONTENTS THEREOF.</p>
-
-<p>The name and trademarks of the copyright holders or the Eclipse
-  Foundation may NOT be used in advertising or publicity pertaining to
-  this document or its contents without specific, written prior
-  permission. Title to copyright in this document will at all times
-  remain with copyright holders.</p>
-
+<p>THE DOCUMENT IS PROVIDED "AS IS," AND TO THE EXTENT PERMITTED BY APPLICABLE LAW THE COPYRIGHT HOLDERS AND THE ECLIPSE FOUNDATION AISBL MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, OR TITLE; THAT THE CONTENTS OF THE DOCUMENT ARE SUITABLE FOR ANY PURPOSE; NOR THAT THE IMPLEMENTATION OF SUCH CONTENTS WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.</p>
+<p>TO THE EXTENT PERMITTED BY APPLICABLE LAW THE COPYRIGHT HOLDERS AND THE ECLIPSE FOUNDATION AISBL WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE DOCUMENT OR THE PERFORMANCE OR IMPLEMENTATION OF THE CONTENTS THEREOF.</p>
+<p>The name and trademarks of the copyright holders or the Eclipse Foundation AISBL may NOT be used in advertising or publicity pertaining to this document or its contents without specific, written prior permission.</p>
 </body>
 </html>

--- a/el/pom.xml
+++ b/el/pom.xml
@@ -141,7 +141,7 @@
 					</header>
 					<bottom><![CDATA[
 Comments to: <a href="mailto:cdi-dev@eclipse.org">cdi-dev@eclipse.org</a>.<br>
-Copyright &#169; 2018,2023 Eclipse Foundation.<br>
+Copyright &#169; 2018,2026 Eclipse Foundation.<br>
 Use is subject to <a href="{@docRoot}/doc-files/speclicense.html" target="_top">license terms</a>.]]>
 					</bottom>
 				</configuration>

--- a/el/src/main/javadoc/doc-files/speclicense.html
+++ b/el/src/main/javadoc/doc-files/speclicense.html
@@ -1,72 +1,33 @@
 <html>
 <head>
-  <title>Eclipse Foundation Specification License - v1.0</title>
+  <title>Eclipse Foundation Specification License - v2.0</title>
 </head>
 <body>
-<h1>Eclipse Foundation Specification License - v1.0</h1>
-<p>By using and/or copying this document, or the Eclipse Foundation
-  document from which this statement is linked, you (the licensee) agree
-  that you have read, understood, and will comply with the following
-  terms and conditions:</p>
-
-<p>Permission to copy, and distribute the contents of this document, or
-  the Eclipse Foundation document from which this statement is linked, in
-  any medium for any purpose and without fee or royalty is hereby
-  granted, provided that you include the following on ALL copies of the
-  document, or portions thereof, that you use:</p>
-
+<h1>Eclipse Foundation Specification License - v2.0</h1>
+<p>This license (the &ldquo;License&rdquo;) governs the use, modification and distribution of a specification generated pursuant to the Eclipse Foundation Specification Process.</p>
+<p>By using the file or document that incorporates this License (the &ldquo;Document&rdquo;), you (the licensee) agree that you have read, understood, and will comply with the following terms and conditions.</p>
+<p>Permission to copy and distribute the contents of the Document, in any medium for any purpose, and without fee or royalty is hereby granted, provided that you include the following on ALL copies of the Document that you copy or distribute:</p>
 <ul>
-  <li> link or URL to the original Eclipse Foundation document.</li>
-  <li>All existing copyright notices, or if one does not exist, a notice
-    (hypertext is preferred, but a textual representation is permitted)
-    of the form: &quot;Copyright &copy; [$date-of-document]
-    &ldquo;Eclipse Foundation, Inc. &lt;&lt;url to this license&gt;&gt;
-    &quot;
-  </li>
+<li>
+<p>link or URL to the Document</p>
+</li>
+<li>
+<p>All existing copyright notices, or if one does not exist, a notice (hypertext is preferred, but a textual representation is permitted) of the form: "Copyright &copy; [date-of-document] Eclipse Foundation AISBL [URL to this license] This document includes material copied from [title and URL of the Eclipse Foundation specification document]."</p>
+</li>
 </ul>
-
-<p>Inclusion of the full text of this NOTICE must be provided. We
-  request that authorship attribution be provided in any software,
-  documents, or other items or products that you create pursuant to the
-  implementation of the contents of this document, or any portion
-  thereof.</p>
-
-<p>No right to create modifications or derivatives of Eclipse Foundation
-  documents is granted pursuant to this license, except anyone may
-  prepare and distribute derivative works and portions of this document
-  in software that implements the specification, in supporting materials
-  accompanying such software, and in documentation of such software,
-  PROVIDED that all such works include the notice below. HOWEVER, the
-  publication of derivative works of this document for use as a technical
-  specification is expressly prohibited.</p>
-
-<p>The notice is:</p>
-
-<p>&quot;Copyright &copy; 2018 Eclipse Foundation. This software or
-  document includes material copied from or derived from [title and URI
-  of the Eclipse Foundation specification document].&quot;</p>
-
+<p>In addition to the license granted above, you are granted the  right to create modifications or derivatives of the Document:</p>
+<ul>
+<li>
+<p>in software that implements the Document, in supporting materials accompanying such software, and in documentation of such software (collectively the &ldquo;Works&rdquo;), such  Works to be made available under terms of your choice  PROVIDED that all such Works include a notice of the form: &ldquo;This [software/document (choose as applicable)] includes material derived from [title and URL of the Eclipse Foundation specification document].&rdquo;; and</p>
+</li>
+<li>
+<p>in materials that demonstrate or describe conformance with the Document PROVIDED that all such materials include a notice of the form: &ldquo;This material demonstrates conformance with the [title and URL of the Eclipse Foundation specification document].&rdquo;</p>
+</li>
+</ul>
+<p>NOTWITHSTANDING THE FOREGOING, the creation or publication of derivative works of the Document or portions of the Document for use as a specification or standard is expressly prohibited.</p>
 <h2>Disclaimers</h2>
-
-<p>THIS DOCUMENT IS PROVIDED &quot;AS IS,&quot; AND THE COPYRIGHT
-  HOLDERS AND THE ECLIPSE FOUNDATION MAKE NO REPRESENTATIONS OR
-  WARRANTIES, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
-  WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE,
-  NON-INFRINGEMENT, OR TITLE; THAT THE CONTENTS OF THE DOCUMENT ARE
-  SUITABLE FOR ANY PURPOSE; NOR THAT THE IMPLEMENTATION OF SUCH CONTENTS
-  WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR
-  OTHER RIGHTS.</p>
-
-<p>THE COPYRIGHT HOLDERS AND THE ECLIPSE FOUNDATION WILL NOT BE LIABLE
-  FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT
-  OF ANY USE OF THE DOCUMENT OR THE PERFORMANCE OR IMPLEMENTATION OF THE
-  CONTENTS THEREOF.</p>
-
-<p>The name and trademarks of the copyright holders or the Eclipse
-  Foundation may NOT be used in advertising or publicity pertaining to
-  this document or its contents without specific, written prior
-  permission. Title to copyright in this document will at all times
-  remain with copyright holders.</p>
-
+<p>THE DOCUMENT IS PROVIDED "AS IS," AND TO THE EXTENT PERMITTED BY APPLICABLE LAW THE COPYRIGHT HOLDERS AND THE ECLIPSE FOUNDATION AISBL MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, OR TITLE; THAT THE CONTENTS OF THE DOCUMENT ARE SUITABLE FOR ANY PURPOSE; NOR THAT THE IMPLEMENTATION OF SUCH CONTENTS WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.</p>
+<p>TO THE EXTENT PERMITTED BY APPLICABLE LAW THE COPYRIGHT HOLDERS AND THE ECLIPSE FOUNDATION AISBL WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE DOCUMENT OR THE PERFORMANCE OR IMPLEMENTATION OF THE CONTENTS THEREOF.</p>
+<p>The name and trademarks of the copyright holders or the Eclipse Foundation AISBL may NOT be used in advertising or publicity pertaining to this document or its contents without specific, written prior permission.</p>
 </body>
 </html>

--- a/lang-model/pom.xml
+++ b/lang-model/pom.xml
@@ -111,7 +111,7 @@
 					</header>
 					<bottom><![CDATA[
 Comments to: <a href="mailto:cdi-dev@eclipse.org">cdi-dev@eclipse.org</a>.<br>
-Copyright &#169; 2018,2023 Eclipse Foundation.<br>
+Copyright &#169; 2018,2026 Eclipse Foundation.<br>
 Use is subject to <a href="{@docRoot}/doc-files/speclicense.html" target="_top">license terms</a>.]]>
 					</bottom>
 				</configuration>

--- a/lang-model/src/main/javadoc/doc-files/speclicense.html
+++ b/lang-model/src/main/javadoc/doc-files/speclicense.html
@@ -1,72 +1,33 @@
 <html>
 <head>
-  <title>Eclipse Foundation Specification License - v1.0</title>
+  <title>Eclipse Foundation Specification License - v2.0</title>
 </head>
 <body>
-<h1>Eclipse Foundation Specification License - v1.0</h1>
-<p>By using and/or copying this document, or the Eclipse Foundation
-  document from which this statement is linked, you (the licensee) agree
-  that you have read, understood, and will comply with the following
-  terms and conditions:</p>
-
-<p>Permission to copy, and distribute the contents of this document, or
-  the Eclipse Foundation document from which this statement is linked, in
-  any medium for any purpose and without fee or royalty is hereby
-  granted, provided that you include the following on ALL copies of the
-  document, or portions thereof, that you use:</p>
-
+<h1>Eclipse Foundation Specification License - v2.0</h1>
+<p>This license (the &ldquo;License&rdquo;) governs the use, modification and distribution of a specification generated pursuant to the Eclipse Foundation Specification Process.</p>
+<p>By using the file or document that incorporates this License (the &ldquo;Document&rdquo;), you (the licensee) agree that you have read, understood, and will comply with the following terms and conditions.</p>
+<p>Permission to copy and distribute the contents of the Document, in any medium for any purpose, and without fee or royalty is hereby granted, provided that you include the following on ALL copies of the Document that you copy or distribute:</p>
 <ul>
-  <li> link or URL to the original Eclipse Foundation document.</li>
-  <li>All existing copyright notices, or if one does not exist, a notice
-    (hypertext is preferred, but a textual representation is permitted)
-    of the form: &quot;Copyright &copy; [$date-of-document]
-    &ldquo;Eclipse Foundation, Inc. &lt;&lt;url to this license&gt;&gt;
-    &quot;
-  </li>
+<li>
+<p>link or URL to the Document</p>
+</li>
+<li>
+<p>All existing copyright notices, or if one does not exist, a notice (hypertext is preferred, but a textual representation is permitted) of the form: "Copyright &copy; [date-of-document] Eclipse Foundation AISBL [URL to this license] This document includes material copied from [title and URL of the Eclipse Foundation specification document]."</p>
+</li>
 </ul>
-
-<p>Inclusion of the full text of this NOTICE must be provided. We
-  request that authorship attribution be provided in any software,
-  documents, or other items or products that you create pursuant to the
-  implementation of the contents of this document, or any portion
-  thereof.</p>
-
-<p>No right to create modifications or derivatives of Eclipse Foundation
-  documents is granted pursuant to this license, except anyone may
-  prepare and distribute derivative works and portions of this document
-  in software that implements the specification, in supporting materials
-  accompanying such software, and in documentation of such software,
-  PROVIDED that all such works include the notice below. HOWEVER, the
-  publication of derivative works of this document for use as a technical
-  specification is expressly prohibited.</p>
-
-<p>The notice is:</p>
-
-<p>&quot;Copyright &copy; 2018 Eclipse Foundation. This software or
-  document includes material copied from or derived from [title and URI
-  of the Eclipse Foundation specification document].&quot;</p>
-
+<p>In addition to the license granted above, you are granted the  right to create modifications or derivatives of the Document:</p>
+<ul>
+<li>
+<p>in software that implements the Document, in supporting materials accompanying such software, and in documentation of such software (collectively the &ldquo;Works&rdquo;), such  Works to be made available under terms of your choice  PROVIDED that all such Works include a notice of the form: &ldquo;This [software/document (choose as applicable)] includes material derived from [title and URL of the Eclipse Foundation specification document].&rdquo;; and</p>
+</li>
+<li>
+<p>in materials that demonstrate or describe conformance with the Document PROVIDED that all such materials include a notice of the form: &ldquo;This material demonstrates conformance with the [title and URL of the Eclipse Foundation specification document].&rdquo;</p>
+</li>
+</ul>
+<p>NOTWITHSTANDING THE FOREGOING, the creation or publication of derivative works of the Document or portions of the Document for use as a specification or standard is expressly prohibited.</p>
 <h2>Disclaimers</h2>
-
-<p>THIS DOCUMENT IS PROVIDED &quot;AS IS,&quot; AND THE COPYRIGHT
-  HOLDERS AND THE ECLIPSE FOUNDATION MAKE NO REPRESENTATIONS OR
-  WARRANTIES, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
-  WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE,
-  NON-INFRINGEMENT, OR TITLE; THAT THE CONTENTS OF THE DOCUMENT ARE
-  SUITABLE FOR ANY PURPOSE; NOR THAT THE IMPLEMENTATION OF SUCH CONTENTS
-  WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR
-  OTHER RIGHTS.</p>
-
-<p>THE COPYRIGHT HOLDERS AND THE ECLIPSE FOUNDATION WILL NOT BE LIABLE
-  FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT
-  OF ANY USE OF THE DOCUMENT OR THE PERFORMANCE OR IMPLEMENTATION OF THE
-  CONTENTS THEREOF.</p>
-
-<p>The name and trademarks of the copyright holders or the Eclipse
-  Foundation may NOT be used in advertising or publicity pertaining to
-  this document or its contents without specific, written prior
-  permission. Title to copyright in this document will at all times
-  remain with copyright holders.</p>
-
+<p>THE DOCUMENT IS PROVIDED "AS IS," AND TO THE EXTENT PERMITTED BY APPLICABLE LAW THE COPYRIGHT HOLDERS AND THE ECLIPSE FOUNDATION AISBL MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, OR TITLE; THAT THE CONTENTS OF THE DOCUMENT ARE SUITABLE FOR ANY PURPOSE; NOR THAT THE IMPLEMENTATION OF SUCH CONTENTS WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.</p>
+<p>TO THE EXTENT PERMITTED BY APPLICABLE LAW THE COPYRIGHT HOLDERS AND THE ECLIPSE FOUNDATION AISBL WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE DOCUMENT OR THE PERFORMANCE OR IMPLEMENTATION OF THE CONTENTS THEREOF.</p>
+<p>The name and trademarks of the copyright holders or the Eclipse Foundation AISBL may NOT be used in advertising or publicity pertaining to this document or its contents without specific, written prior permission.</p>
 </body>
 </html>

--- a/spec/src/main/asciidoc/license-final.asciidoc
+++ b/spec/src/main/asciidoc/license-final.asciidoc
@@ -14,7 +14,7 @@ Release: {revdate}
 
 === Final license
 
-Copyright 2018,2023 Eclipse Foundation.
+Copyright 2018,2026 Eclipse Foundation.
 
 This specification is licensed under the Eclipse Foundation Specification License 1.0; this specification is based on material that is licensed under the Apache License, version 2.0.
 

--- a/spec/src/main/asciidoc/license-final.asciidoc
+++ b/spec/src/main/asciidoc/license-final.asciidoc
@@ -21,8 +21,6 @@ This specification is licensed under the Eclipse Foundation Specification Licens
 
 === Eclipse Foundation Specification License - v2.0
 
-(Copy of the EFSL license link:https://www.eclipse.org/legal/efsl.php[here])
-
 This license (the "License") governs the use, modification and distribution of a specification generated pursuant to the Eclipse Foundation Specification Process.
 
 By using the file or document that incorporates this License (the "Document"), you (the licensee) agree that you have read, understood, and will comply with the following terms and conditions.

--- a/spec/src/main/asciidoc/license-final.asciidoc
+++ b/spec/src/main/asciidoc/license-final.asciidoc
@@ -16,33 +16,33 @@ Release: {revdate}
 
 Copyright 2018,2026 Eclipse Foundation.
 
-This specification is licensed under the Eclipse Foundation Specification License 1.0; this specification is based on material that is licensed under the Apache License, version 2.0.
+This specification is licensed under the Eclipse Foundation Specification License 2.0; this specification is based on material that is licensed under the Apache License, version 2.0.
 
 
-=== Eclipse Foundation Specification License - v1.0
+=== Eclipse Foundation Specification License - v2.0
 
 (Copy of the EFSL license link:https://www.eclipse.org/legal/efsl.php[here])
 
-By using and/or copying this document, or the Eclipse Foundation document from which this statement is linked, you (the licensee) agree that you have read, understood, and will comply with the following terms and conditions:
+This license (the "License") governs the use, modification and distribution of a specification generated pursuant to the Eclipse Foundation Specification Process.
 
-Permission to copy, and distribute the contents of this document, or the Eclipse Foundation document from which this statement is linked, in any medium for any purpose and without fee or royalty is hereby granted, provided that you include the following on ALL copies of the document, or portions thereof, that you use:
+By using the file or document that incorporates this License (the "Document"), you (the licensee) agree that you have read, understood, and will comply with the following terms and conditions.
 
-* link or URL to the original Eclipse Foundation document.
-* All existing copyright notices, or if one does not exist, a notice (hypertext is preferred, but a textual representation is permitted) of the form:
-"Copyright © [$date-of-document] Eclipse Foundation, Inc. link:https://www.eclipse.org/legal/efsl.php[EFSL]"
+Permission to copy and distribute the contents of the Document, in any medium for any purpose, and without fee or royalty is hereby granted, provided that you include the following on ALL copies of the Document that you copy or distribute:
 
-Inclusion of the full text of this NOTICE must be provided. We request that authorship attribution be provided in any software, documents, or other items or products that you create pursuant to the implementation of the contents of this document, or any portion thereof.
+* link or URL to the Document
+* All existing copyright notices, or if one does not exist, a notice (hypertext is preferred, but a textual representation is permitted) of the form: "Copyright © [date-of-document] Eclipse Foundation AISBL [URL to this license] This document includes material copied from [title and URL of the Eclipse Foundation specification document]."
 
-No right to create modifications or derivatives of Eclipse Foundation documents is granted pursuant to this license, except anyone may prepare and distribute derivative works and portions of this document in software that implements the specification, in supporting materials accompanying such software, and in documentation of such software, PROVIDED that all such works include the notice below. HOWEVER, the publication of derivative works of this document for use as a technical specification is expressly prohibited.
+In addition to the license granted above, you are granted the right to create modifications or derivatives of the Document:
 
-The notice is:
+* in software that implements the Document, in supporting materials accompanying such software, and in documentation of such software (collectively the "Works"), such Works to be made available under terms of your choice PROVIDED that all such Works include a notice of the form: "This [software/document (choose as applicable)] includes material derived from [title and URL of the Eclipse Foundation specification document]."; and
+* in materials that demonstrate or describe conformance with the Document PROVIDED that all such materials include a notice of the form: "This material demonstrates conformance with the [title and URL of the Eclipse Foundation specification document]."
 
-Copyright © 2018,2022 Eclipse Foundation. This software or document includes material copied from or derived from Jakarta Contexts and Dependency Injection https://projects.eclipse.org/projects/ee4j.cdi
+NOTWITHSTANDING THE FOREGOING, the creation or publication of derivative works of the Document or portions of the Document for use as a specification or standard is expressly prohibited.
 
 Disclaimers
 
-THIS DOCUMENT IS PROVIDED "AS IS," AND THE COPYRIGHT HOLDERS AND THE ECLIPSE FOUNDATION MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, OR TITLE; THAT THE CONTENTS OF THE DOCUMENT ARE SUITABLE FOR ANY PURPOSE; NOR THAT THE IMPLEMENTATION OF SUCH CONTENTS WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
+THE DOCUMENT IS PROVIDED "AS IS," AND TO THE EXTENT PERMITTED BY APPLICABLE LAW THE COPYRIGHT HOLDERS AND THE ECLIPSE FOUNDATION AISBL MAKE NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, OR TITLE; THAT THE CONTENTS OF THE DOCUMENT ARE SUITABLE FOR ANY PURPOSE; NOR THAT THE IMPLEMENTATION OF SUCH CONTENTS WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR OTHER RIGHTS.
 
-THE COPYRIGHT HOLDERS AND THE ECLIPSE FOUNDATION WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE DOCUMENT OR THE PERFORMANCE OR IMPLEMENTATION OF THE CONTENTS THEREOF.
+TO THE EXTENT PERMITTED BY APPLICABLE LAW THE COPYRIGHT HOLDERS AND THE ECLIPSE FOUNDATION AISBL WILL NOT BE LIABLE FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF ANY USE OF THE DOCUMENT OR THE PERFORMANCE OR IMPLEMENTATION OF THE CONTENTS THEREOF.
 
-The name and trademarks of the copyright holders or the Eclipse Foundation may NOT be used in advertising or publicity pertaining to this document or its contents without specific, written prior permission. Title to copyright in this document will at all times remain with copyright holders.
+The name and trademarks of the copyright holders or the Eclipse Foundation AISBL may NOT be used in advertising or publicity pertaining to this document or its contents without specific, written prior permission.

--- a/spec/src/main/asciidoc/preface.asciidoc
+++ b/spec/src/main/asciidoc/preface.asciidoc
@@ -33,6 +33,32 @@ This document is organized in 4 parts:
 
 === Major changes
 
+==== Jakarta Contexts and Dependency Injection 5.0
+
+link:https://jakarta.ee/specifications/cdi/5.0/[CDI 5.0] increases the minimum required Java version to Java SE 17.
+
+Several additions have been made to the programming model:
+
+* A new `@Reserve` annotation provides a means of declaring a default bean.
+* A new `@Eager` annotation requests eager initialization of `@ApplicationScoped` beans.
+* A new `@AutoClose` annotation arranges for `close()` to be invoked automatically on `AutoCloseable` beans during their destruction.
+* Asynchronous invokers have been introduced via the `AsyncHandler` API.
+* Synthetic beans may now declare injection points through the new `SyntheticInjections` API.
+* Build compatible extensions can now be registered programmatically in CDI SE.
+* The build compatible extension `@Registration` annotation may now specify parameterized types.
+* The behavior of `InjectionPoint` when a bean is obtained via `CDI.current()` has been defined.
+
+The concept of global scopes has been introduced and the application scope is now a global scope.
+
+Trimming is no longer allowed in non-explicit bean archives.
+
+The Unified EL integration methods on `BeanManager`, which were deprecated and moved to the `ELAwareBeanManager` interface in CDI 4.1, have been removed. All usage of and references to the Java `SecurityManager` have been removed. The existing `SyntheticBeanCreator` and `SyntheticBeanDisposer` methods that do not use `SyntheticInjections` have been deprecated for removal.
+
+The Maven coordinates of the CDI API and TCK artifacts have changed: both the `groupId` and `artifactId` have changed, for example `jakarta.enterprise:jakarta.enterprise.cdi-api` is now `jakarta.cdi:jakarta.cdi-api`. The CDI API provides relocation artifacts for the 5.0 release to ease migration; the CDI TCK coordinates have changed as well but without relocation artifacts.
+
+A new `beans.xml` 5.0 schema file has been added and the namespace of the
+`beans_5_0.xsd` schema file is `xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee"`. The only change in the schema is to update the default value for the version to 5.0. The schema is backward compatible with CDI 4.1.
+
 ==== Jakarta Contexts and Dependency Injection 4.1
 
 link:https://jakarta.ee/specifications/cdi/4.1/[CDI 4.1] no longer specifies integration with Jakarta EE. This will now be specified in the Jakarta EE Platform, Web Profile and Core Profile specifications.


### PR DESCRIPTION
Incorporating changes from the ballot review - https://github.com/jakartaee/specifications/pull/917#issuecomment-5320373100

These include (each has a separate commit):
* javadoc footer showing 2024 instead of 2026
* Missing 5.0 summary in the spec doc preface
* Update EFSL to version 2.0
  * Taken from https://www.eclipse.org/legal/efsl/ and replacing the 1.0 version we had until now
  * @Emily-Jiang said she will verify if this one is truly needed; so I say we wait with merging this until we get said confirmation

Once we merge this, we should drop the staging repo and re-do the release to get the correct javadoc JARs and other artifacts.